### PR TITLE
Dropped frames fixes

### DIFF
--- a/cancat/__init__.py
+++ b/cancat/__init__.py
@@ -1392,6 +1392,96 @@ class CanInterface(object):
         msg = struct.pack('>IIIIIIII', 0, 0, 0, 0, 0, 0, 0, 0)
         return self._send(CMD_SET_FILT_MASK, msg)
 
+    def _test_throughput(self):
+        '''
+        Use in conjuction with the M2_TEST_FW to test throughput
+
+        Connect one CanCat up to another M2 or Arduino DUE device runing the M2_TEST_FW firmware
+        and run this function to perform a throughput test. No other device should be connected
+        to allow the test to run unimpeded by other CAN traffic.
+        '''
+        self.clearCanMsgs()
+        self.CANxmit(0x0010, "TEST")
+        for i in range(6, 3, -1):
+            print "Time remaining: ", i*10, " seconds"
+            time.sleep(10)
+        self.CANxmit(0x810, "TEST", extflag=True)
+        for i in range(3, 0, -1):
+            print "Time remaining: ", i*10, " seconds"
+            time.sleep(10)
+                
+        out_of_order_count = 0
+        msg_count = 0
+        prev_val = 0xFF
+        for foo in self.genCanMsgs(arbids=[0x00]):
+            msg_count += 1
+            prev_val += 1
+            if prev_val > 0xff:
+                prev_val = 0
+            if prev_val != ord(foo[3]):
+                out_of_order_count += 1
+                prev_val = ord(foo[3])
+        if (out_of_order_count > 0):
+            print "ERROR: 11 bit IDs, 1 byte messages, ", out_of_order_count, " Messages received out of order"
+        elif (msg_count != 181810):
+            print "ERROR: Received ", msg_count, " out of expected 181810 message"
+        else:
+            print "PASS: 11 bit IDs, 1 byte messages"
+        
+        out_of_order_count = 0
+        msg_count = 0
+        prev_val = 0xFF
+        for foo in self.genCanMsgs(arbids=[0x01]):
+            msg_count += 1
+            prev_val += 1
+            if prev_val > 0xff:
+                prev_val = 0
+            if prev_val != ord(foo[3][0]):
+                out_of_order_count += 1
+                prev_val = ord(foo[3][0])
+        if (out_of_order_count > 0):
+            print "ERROR: 11 bit IDs, 8 byte messages, ", out_of_order_count, " Messages received out of order"
+        elif (msg_count != 90090):
+            print "ERROR: Received ", msg_count, " out of expected 90090 message"
+        else:
+            print "PASS: 11 bit IDs, 8 byte messages"
+        
+        out_of_order_count = 0
+        msg_count = 0
+        prev_val = 0xFF
+        for foo in self.genCanMsgs(arbids=[0x800]):
+            msg_count += 1
+            prev_val += 1
+            if prev_val > 0xff:
+                prev_val = 0
+            if prev_val != ord(foo[3]):
+                out_of_order_count += 1
+                prev_val = ord(foo[3])
+        if (out_of_order_count > 0):
+            print "ERROR: 29 bit IDs, 1 byte messages, ", out_of_order_count, " Messages received out of order"
+        elif (msg_count != 133330):
+            print "ERROR: Received ", msg_count, " out of expected 133330 message"
+        else:
+            print "PASS: 29 bit IDs, 1 byte messages"
+        
+        out_of_order_count = 0
+        msg_count = 0
+        prev_val = 0xFF
+        for foo in self.genCanMsgs(arbids=[0x801]):
+            msg_count += 1
+            prev_val += 1
+            if prev_val > 0xff:
+                prev_val = 0
+            if prev_val != ord(foo[3][0]):
+                out_of_order_count += 1
+                prev_val = ord(foo[3][0])
+        if (out_of_order_count > 0):
+            print "ERROR: 29 bit IDs, 8 byte messages, ", out_of_order_count, " Messages received out of order"
+        elif (msg_count != 76330):
+            print "ERROR: Received ", msg_count, " out of expected 76330 message"
+        else:
+            print "PASS: 29 bit IDs, 8 byte messages"
+
 
 class CanControl(cmd.Cmd):
     '''

--- a/sketches/M2_CAN_haz_bus/M2_CAN_haz_bus.ino
+++ b/sketches/M2_CAN_haz_bus/M2_CAN_haz_bus.ino
@@ -237,9 +237,9 @@ void loop()
                 mask   = serial_buffer[6]  | (serial_buffer[5] << 8)  | (serial_buffer[4] << 16)  | (serial_buffer[3] << 24);
                 filter = serial_buffer[14] | (serial_buffer[13] << 8) | (serial_buffer[12] << 16) | (serial_buffer[11] << 24);
                 if (mask <= 0x7FF) // If it's an 11-bit identifier
-                    device->setRXFilter(5, filter, mask, false);
+                    device->setRXFilter(5, filter, mask, true);
                 else
-                    device->setRXFilter(6, filter, mask, true);
+                    device->setRXFilter(6, filter, mask, false);
                 break;
 
             case CMD_CAN_SEND_ISOTP:

--- a/sketches/M2_CAN_haz_bus/citm.cpp
+++ b/sketches/M2_CAN_haz_bus/citm.cpp
@@ -39,10 +39,21 @@ uint8_t Init_CITM(uint8_t baud)
     Can1.init(baud_rates_table[baud]);
     Can0.setNumTXBoxes(2);
     Can1.setNumTXBoxes(2);
-    Can0.setRXFilter(4, 0, 0, false);
-    Can0.setRXFilter(5, 0, 0, true);
-    Can1.setRXFilter(4, 0, 0, false);
-    Can1.setRXFilter(5, 0, 0, true);
+
+    // Disable unused mailboxes
+    Can0.mailbox_set_mode(0, 0);
+    Can0.mailbox_set_mode(1, 0);
+    Can0.mailbox_set_mode(2, 0);
+    Can0.mailbox_set_mode(3, 0);
+    Can1.mailbox_set_mode(0, 0);
+    Can1.mailbox_set_mode(1, 0);
+    Can1.mailbox_set_mode(2, 0);
+    Can1.mailbox_set_mode(3, 0);
+    
+    Can0.setRXFilter(4, 0, 0, true);
+    Can0.setRXFilter(5, 0, 0, false);
+    Can1.setRXFilter(4, 0, 0, true);
+    Can1.setRXFilter(5, 0, 0, false);
     Can0.setCallback(4, CITM_Can0_cb);
     Can0.setCallback(5, CITM_Can0_cb);
     Can1.setCallback(4, CITM_Can1_cb);
@@ -50,4 +61,3 @@ uint8_t Init_CITM(uint8_t baud)
     initialized = 1;
     return 1; //TODO: Error Checking
 }
-

--- a/sketches/M2_CAN_haz_bus/isotp.cpp
+++ b/sketches/M2_CAN_haz_bus/isotp.cpp
@@ -43,14 +43,14 @@ void IsoTP_cb(CAN_FRAME *frame, CANRaw *device)
             log("Received ABORT from ISOTP TX", 28);
             if (mode != CMD_CAN_MODE_CITM)
             {
-                device->setRXFilter(0, 0, 0x7FF, false);
+                device->mailbox_set_mode(0, 0); // Disable ISOTP Mailbox
                 device->detachCANInterrupt(0);
             }
             else
             {
-                Can0.setRXFilter(0, 0, 0x7FF, false);
+                Can0.mailbox_set_mode(0, 0); // Disable ISOTP Mailbox
                 Can0.detachCANInterrupt(0);
-                Can1.setRXFilter(0, 0, 0x7FF, false);
+                Can1.mailbox_set_mode(0, 0); // Disable ISOTP Mailbox
                 Can1.detachCANInterrupt(0);
             }
             isotp_tx_index = 0;
@@ -69,14 +69,14 @@ void IsoTP_cb(CAN_FRAME *frame, CANRaw *device)
             log("Block size specified, which is unimplemented", 67);
             if (mode != CMD_CAN_MODE_CITM)
             {
-                device->setRXFilter(0, 0, 0x7FF, false);
+                device->mailbox_set_mode(0, 0); // Disable ISOTP Mailbox
                 device->detachCANInterrupt(0);
             }
             else
             {
-                Can0.setRXFilter(0, 0, 0x7FF, false);
+                Can0.mailbox_set_mode(0, 0); // Disable ISOTP Mailbox
                 Can0.detachCANInterrupt(0);
-                Can1.setRXFilter(0, 0, 0x7FF, false);
+                Can1.mailbox_set_mode(0, 0); // Disable ISOTP Mailbox
                 Can1.detachCANInterrupt(0);
             }
             isotp_tx_index = 0;
@@ -238,13 +238,16 @@ uint8_t SendIsoTPFrame(uint8_t serial_buffer[], uint16_t serial_buf_count)
         {
             device->setRXFilter(0, isotp_rx_arbid, (isotp_tx_extended) ? 0x1FFFFFFF : 0x7FF, isotp_tx_extended);
             device->setCallback(0, (mode == CMD_CAN_MODE_SNIFF_CAN0) ? IsoTP_Can0_cb : IsoTP_Can1_cb);
+            device->mailbox_set_mode(0, CAN_MB_RX_MODE); // Enable mailbox
         }
         else if(mode == CMD_CAN_MODE_CITM)
         {
             Can0.setRXFilter(0, isotp_rx_arbid, (isotp_tx_extended) ? 0x1FFFFFFF : 0x7FF, isotp_tx_extended);
             Can0.setCallback(0, IsoTP_Can0_cb);
+            Can0.mailbox_set_mode(0, CAN_MB_RX_MODE); // Enable mailbox
             Can1.setRXFilter(0, isotp_rx_arbid, (isotp_tx_extended) ? 0x1FFFFFFF : 0x7FF, isotp_tx_extended);
             Can1.setCallback(0, IsoTP_Can1_cb);
+            Can1.mailbox_set_mode(0, CAN_MB_RX_MODE); // Enable mailbox
         }
         isotp_tx_go = 0;
         isotp_tx_index = 6;
@@ -280,15 +283,16 @@ uint8_t RecvIsoTPFrame(uint8_t serial_buffer[])
     {
         device->setRXFilter(0, isotp_rx_arbid, (isotp_tx_extended) ? 0x1FFFFFFF : 0x7FF, isotp_tx_extended);
         device->setCallback(0, (mode == CMD_CAN_MODE_SNIFF_CAN0) ? IsoTP_Can0_cb : IsoTP_Can1_cb);
+        device->mailbox_set_mode(0, CAN_MB_RX_MODE); // Enable mailbox
     }
     else if(mode == CMD_CAN_MODE_CITM)
     {
         Can0.setRXFilter(0, isotp_rx_arbid, (isotp_tx_extended) ? 0x1FFFFFFF : 0x7FF, isotp_tx_extended);
         Can0.setCallback(0, IsoTP_Can0_cb);
+        Can0.mailbox_set_mode(0, CAN_MB_RX_MODE); // Enable mailbox
         Can1.setRXFilter(0, isotp_rx_arbid, (isotp_tx_extended) ? 0x1FFFFFFF : 0x7FF, isotp_tx_extended);
         Can1.setCallback(0, IsoTP_Can1_cb);
+        Can1.mailbox_set_mode(0, CAN_MB_RX_MODE); // Enable mailbox
     }
     return 0; //TODO: Error checking
 }
-
-

--- a/sketches/M2_CAN_haz_bus/sniffing.cpp
+++ b/sketches/M2_CAN_haz_bus/sniffing.cpp
@@ -37,9 +37,17 @@ uint8_t Init_Sniff(uint8_t baud)
         autobaud(device);
     else
         device->init(baud_rates_table[baud]);
-    
-    device->setRXFilter(5, 0, 0, false);
-    device->setRXFilter(6, 0, 0, true);
+
+    // Disable unused mailboxes
+    device->mailbox_set_mode(0, 0);
+    device->mailbox_set_mode(1, 0);
+    device->mailbox_set_mode(2, 0);
+    device->mailbox_set_mode(3, 0);
+    device->mailbox_set_mode(4, 0);
+
+    // Set up mailbox 5 to receive basic and mailbox 6 to receive extended messages
+    device->setRXFilter(5, 0, 0, true);
+    device->setRXFilter(6, 0, 0, false);
     
     if(device == &Can0)
     {
@@ -54,4 +62,3 @@ uint8_t Init_Sniff(uint8_t baud)
     initialized = 1;
     return 1; //TODO: Error Checking
 }
-

--- a/sketches/M2_TEST_FW/M2_TEST_FW.ino
+++ b/sketches/M2_TEST_FW/M2_TEST_FW.ino
@@ -1,0 +1,147 @@
+/**
+ * This file provides the Arduino setup and loop functions, any general-purpose functionality such as 
+ * creating and sending CAN frames and handles the serial communication.
+ */
+
+ /*   
+  *  CAN Frames Per Second:
+  *  
+  *  For a CAN Frame with an 11-bit identifier and an 8 byte message length, the frame will be 111 bits total 
+  *  length not accounting for any stuff bits. Frames per second is:
+  *  1MPBS   - 9009
+  *  500KBPs - 4504
+  *  125KBPs - 1126
+  *  
+  *  11 bit identifier with 1 byte message length, frame will be 55 bits total length not accounting for 
+  *  stuff bits.
+  *  1MBPs   - 18181
+  *  500KBPs - 9090
+  *  125KPBs - 2272
+  *  
+  *  29-bit identifier with 8 byte message length, frame will be 131 bits total
+  *  1MBPs   - 7633
+  *  500KBPs - 3816
+  *  125KBPs - 954
+  *  
+  *  29-bit identifier with 1 byte message length, frame will be 75 bits total
+  *  1MBPs   - 13333
+  *  500KBPs - 6666
+  *  125KBPs - 1666
+  */
+
+#include <due_can.h>
+
+#define Serial SerialUSB
+CAN_FRAME frame_basic;
+CAN_FRAME frame_extended;
+uint8_t start_test_basic = 0;
+uint8_t start_test_extended = 0;
+
+/* Callback for Can 0 */
+void CanRXCallback_basic(CAN_FRAME *frame)
+{
+    if(frame->data.bytes[0] == 'T' && frame->data.bytes[1] == 'E' && frame->data.bytes[2] == 'S' && frame->data.bytes[3] == 'T')
+    {
+        start_test_basic = 1;
+    }
+}
+
+void CanRXCallback_extended(CAN_FRAME *frame)
+{
+    if(frame->data.bytes[0] == 'T' && frame->data.bytes[1] == 'E' && frame->data.bytes[2] == 'S' && frame->data.bytes[3] == 'T')
+    {
+        start_test_extended = 1;
+    }
+}
+
+void setup()
+{
+    //start serial port
+    Serial.begin(250000);
+
+    // Start CAN peripheral
+    Can0.init(1000000);
+    Can0.setRXFilter(1, 0x10, 0x7FF, false);
+    Can0.setRXFilter(0, 0x810, 0x1FFFFFFF, true);
+    Can0.setCallback(1, CanRXCallback_basic);
+    Can0.setCallback(0, CanRXCallback_extended);
+
+    frame_basic.id = 0x00;
+    frame_basic.extended = false;
+    frame_basic.length = 1;
+    frame_basic.data.byte[0] = 0;
+    frame_basic.data.byte[1] = 0xAA;
+    frame_basic.data.byte[2] = 0xAA;
+    frame_basic.data.byte[3] = 0xAA;
+    frame_basic.data.byte[4] = 0xAA;
+    frame_basic.data.byte[5] = 0xAA;
+    frame_basic.data.byte[6] = 0xAA;
+    frame_basic.data.byte[7] = 0xAA;
+    
+    frame_extended.id = 0x800;
+    frame_extended.extended = true;
+    frame_extended.length = 1;
+    frame_extended.data.byte[0] = 0;
+    frame_extended.data.byte[1] = 0xAA;
+    frame_extended.data.byte[2] = 0xAA;
+    frame_extended.data.byte[3] = 0xAA;
+    frame_extended.data.byte[4] = 0xAA;
+    frame_extended.data.byte[5] = 0xAA;
+    frame_extended.data.byte[6] = 0xAA;
+    frame_extended.data.byte[7] = 0xAA;
+}
+
+void loop()
+{
+    if(start_test_basic == 1)
+    {
+        frame_basic.length = 1; // Send 1 byte CAN frames as fast as possible
+        frame_basic.id = 0x00; // User arbid 0 for these messages
+        for (int i = 0; i < 181810; i++) // Send ten seconds of messages
+        {
+            while(!Can0.sendFrame(frame_basic));
+            frame_basic.data.byte[0]++;
+        }
+        frame_basic.data.byte[0] = 0;
+
+        frame_basic.length = 8; // Send 8 byte CAN frames as fast as possible
+        frame_basic.id = 0x01; // User arbid 1 for these messages
+        for (int i = 0; i < 90090; i++) // Send ten seconds of messages
+        {
+            while(!Can0.sendFrame(frame_basic));
+            frame_basic.data.byte[0]++;
+        }
+        frame_basic.data.byte[0] = 0;
+        start_test_basic = 0;
+    }
+
+    
+    if(start_test_extended == 1)
+    {
+        frame_extended.length = 1; // Send 1 byte CAN frames as fast as possible
+        frame_extended.id = 0x800; // Use arbid 800 for these messages
+        for (int i = 0; i < 133330; i++) // Send ten seconds of messages
+        {
+            while(!Can0.sendFrame(frame_extended));
+            frame_extended.data.byte[0]++;
+        }
+        frame_extended.data.byte[0] = 0;
+
+        frame_extended.length = 8; // Send 8 byte CAN frames as fast as possible
+        frame_extended.id = 0x801; // Use arbid 801 for these messages
+        for (int i = 0; i < 76330; i++) // Send ten seconds of messages
+        {
+            while(!Can0.sendFrame(frame_extended));
+            frame_extended.data.byte[0]++;
+        }
+        frame_extended.data.byte[0] = 0;
+
+        start_test_extended = 0;
+    }
+}        
+
+
+
+/*********************************************************************************************************
+  END FILE
+*********************************************************************************************************/


### PR DESCRIPTION
Read the lengthy commit message, but in summary, this merge:

Fixes issues with dropping frames under high load by disabling unused mailboxes

Fixes issue with sometimes receiving extended CAN frame in basic CAN frame mailbox by placing extended CAN frame mailbox first. I suspect this is masking a hardware issue, but that requires further investigation.

Adds a test firmware and function to CanCat to allow testing CAN in high-throughput situations.