### PR TITLE
re-create threading events on restore session

### DIFF
--- a/cancat/__init__.py
+++ b/cancat/__init__.py
@@ -967,6 +967,9 @@ class CanInterface(object):
         self.bookmark_info = me.get('bookmark_info')
         self.comments = me.get('comments')
 
+        for cmd in self._messages:
+            self._msg_events[cmd] = threading.Event()
+
     def saveSessionToFile(self, filename=None):
         '''
         Saves the current analysis session to the filename given


### PR DESCRIPTION
Fix to ensure sessions get restored in a way that you can then replay messages.