### PR TITLE
python3 and UDS fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ build/
 *.elf
 *~
 .*.sw?
+
+build/
+dist/
+cancat.egg-info/

--- a/cancat/__init__.py
+++ b/cancat/__init__.py
@@ -318,7 +318,7 @@ class CanInterface(object):
 
         returns a list of the messages
         '''
-        allmsgs = self.recvall(CMD_CAN_RECV) 
+        allmsgs = self.recvall(CMD_CAN_RECV)
 
         # Clear the bookmarks as well because they are no longer meaningful
         self.bookmarks = []
@@ -336,7 +336,7 @@ class CanInterface(object):
 
 
         while not self._config['shutdown']:
-            try:    
+            try:
                 if not self._config['go']:
                     time.sleep(.4)
                     continue
@@ -883,7 +883,7 @@ class CanInterface(object):
             # re-create the messages handle
             if messages == None:
                 messages = self._messages.get(self._msg_source_idx, None)
-        
+
             # if we're off the end of the original request, and "tailing"
             if messages != None:
                 if tail and idx >= stop:
@@ -1038,7 +1038,14 @@ class CanInterface(object):
         see: saveSessionToFile()
         '''
         loadedFile = open(filename, 'rb')
-        me = pickle.load(loadedFile)
+        me = pickle.load(loadedFile, encoding='latin1')
+
+        # Go through the msgs and turn them into bytes
+        for cmd in me['messages']:
+            for i in range(len(me['messages'][cmd])):
+                ts, msg = me['messages'][cmd][i]
+                if isinstance(msg, str):
+                    me['messages'][cmd][i] = (ts, msg.encode('latin-1'))
 
         self.restoreSession(me, force=force)
         self._filename = filename
@@ -1064,7 +1071,7 @@ class CanInterface(object):
 
         for cmd in self._messages:
             self._msg_events[cmd] = threading.Event()
-            
+
     def saveSessionToFile(self, filename=None):
         '''
         Saves the current analysis session to the filename given
@@ -1598,13 +1605,13 @@ class CanInterface(object):
     def _printCanRegs(self):
         self._send(CMD_PRINT_CAN_REGS, "")
 
-    def _bytesHelper(self, msg): 
+    def _bytesHelper(self, msg):
         if isinstance(msg, six.string_types):
             if sys.version_info < (3, 0):
                 msg = bytes(msg)
             else:
                 msg = bytes(msg, 'raw_unicode_escape')
-        
+
         return msg
 
 def getAscii(msg, minbytes=3):

--- a/cancat/scripts/canmap.py
+++ b/cancat/scripts/canmap.py
@@ -376,7 +376,7 @@ def main():
 
     if args.verbose == 1:
         loglevel = log.DEBUG
-    elif args.verbose >= 2:
+    elif args.verbose and args.verbose >= 2:
         loglevel = log.DETAIL
     else:
         loglevel = log.WARNING

--- a/cancat/uds/__init__.py
+++ b/cancat/uds/__init__.py
@@ -9,14 +9,14 @@ import threading
 
 import cancat.iso_tp as cisotp
 
-# In 11-bit CAN, an OBD2 tester typically sends requests with an ID of 7DF, and 
-# can accept response messages on IDs 7E8 to 7EF, requests to a specific ECU can 
-# be sent from ID 7E0 to 7E7.  So the non-OBD2 range normally ends at 7D7, 
+# In 11-bit CAN, an OBD2 tester typically sends requests with an ID of 7DF, and
+# can accept response messages on IDs 7E8 to 7EF, requests to a specific ECU can
+# be sent from ID 7E0 to 7E7.  So the non-OBD2 range normally ends at 7D7,
 # although I can't find a specific "standard" for this.
 #
-# In 29-bit CAN an OBD2 tester typically sends requests with an ID of 0x18DB33F1 
-# where 0x18DBxxxx indicates this is an OBD2 message, 0x33 indicates this 
-# message is for the OBD2 ECU(s), and 0xF1 is the tester.  Normal UDS messages 
+# In 29-bit CAN an OBD2 tester typically sends requests with an ID of 0x18DB33F1
+# where 0x18DBxxxx indicates this is an OBD2 message, 0x33 indicates this
+# message is for the OBD2 ECU(s), and 0xF1 is the tester.  Normal UDS messages
 # use a prefix of 0x18DAxxxx.
 # 0xF1 is used as a tester address in normal UDS messaging as well.
 ARBID_CONSTS = {
@@ -224,9 +224,9 @@ class UDS(object):
     def SendTesterPresent(self):
         while self.TesterPresent is True:
             if self.TesterPresentRequestsResponse:
-                self.c.CANxmit(self.tx_arbid, "023E000000000000".decode('hex'))
+                self.c.CANxmit(self.tx_arbid, b"\x02\x3E\x00\x00\x00\x00\x00\x00")
             else:
-                self.c.CANxmit(self.tx_arbid, "023E800000000000".decode('hex'))
+                self.c.CANxmit(self.tx_arbid, b"\x02\x3E\x80\x00\x00\x00\x00\x00")
             time.sleep(2.0)
 
     def StartTesterPresent(self, request_response=True):
@@ -240,14 +240,14 @@ class UDS(object):
         self.TesterPresent = False
         if self.t is not None:
             self.t.join(5.0)
-            if self.t.isAlive():
-                if self.verbose: 
+            if self.t.is_alive():
+                if self.verbose:
                     print("Error killing Tester Present thread")
             self.t = None
 
     def DiagnosticSessionControl(self, session):
         currIdx = self.c.getCanMsgCount()
-        return self._do_Function(SVC_DIAGNOSTICS_SESSION_CONTROL, chr(session), service=0x50)
+        return self._do_Function(SVC_DIAGNOSTICS_SESSION_CONTROL, data=struct.pack('>B', session), service=0x50)
 
     def ReadMemoryByAddress(self, address, size):
         currIdx = self.c.getCanMsgCount()
@@ -285,7 +285,7 @@ class UDS(object):
         except TypeError:
             print("Cannot parse addressAndLengthFormatIdentifier", hex(addr_format))
             return None
-        msg = self.xmit_recv("\x34" + struct.pack(pack_fmt_str, data_format, addr_format, addr, len(data)), extflag=self.extflag, service = 0x74)
+        msg = self.xmit_recv(b"\x34" + struct.pack(pack_fmt_str, data_format, addr_format, addr, len(data)), extflag=self.extflag, service = 0x74)
 
         # Parse the response
         if msg[0] != 0x74:
@@ -301,7 +301,7 @@ class UDS(object):
         data_idx = 0
         block_idx = 1
         while data_idx < len(data):
-            msg = self.xmit_recv("\x36" + chr(block_idx) + data[data_idx:data_idx+max_txfr_len-2], extflag=self.extflag, service = 0x76)
+            msg = self.xmit_recv(b"\x36" + struct.pack('>B', block_idx) + data[data_idx:data_idx+max_txfr_len-2], extflag=self.extflag, service = 0x76)
             data_idx += max_txfr_len - 2
             block_idx += 1
             if block_idx > 0xff:
@@ -445,8 +445,11 @@ class UDS(object):
 
         else:
             seed = msg[2:]
-            hexified_seed = " ".join(x.encode('hex') for x in seed)
-            key = str(bytearray(self._key_from_seed(hexified_seed, key)))
+            if isinstance(key, str):
+                # If key is a string convert it to bytes
+                key = bytes(self._key_from_seed(seed, bytes.fromhex(key.replace(' ', ''))))
+            else:
+                key = bytes(self._key_from_seed(seed, key))
 
             msg = self._do_Function(SVC_SECURITY_ACCESS, subfunc=level+1, data=key, service = 0x67)
             return msg
@@ -460,7 +463,7 @@ class UDS(object):
            Returns the key, as a string of key bytes.
         """
         print("Not implemented in this class")
-        return 0
+        return []
 
 
 def printUDSSession(c, tx_arbid, rx_arbid=None, paginate=45):

--- a/cancat/uds/__init__.py
+++ b/cancat/uds/__init__.py
@@ -394,8 +394,7 @@ class UDS(object):
         pass
     def InputOutputControlByIdentifier(self, iodid):
         pass
-    def RoutineControl(self, rid):
-        pass
+
     def TransferData(self, did):
         pass
     def RequestTransferExit(self):
@@ -403,7 +402,18 @@ class UDS(object):
     def ControlDTCSetting(self):
         pass
 
-
+    def RoutineControl(self, action, routine, *args):
+        """
+        action: 1 for start, 0 for stop
+        routine: 2 byte value for which routine to call
+        *args: any additional arguments (must already be bytes)
+        """
+        # Extra data for routine control is initially just the routine, but
+        # accepts additional bytes
+        data = struct.pack('>H', routine)
+        for arg in args:
+            data += arg
+        return self._do_Function(SVC_ROUTINE_CONTROL, subfunc=action, data=data)
 
     def ScanDIDs(self, start=0, end=0x10000, delay=0):
         success = []

--- a/cancat/uds/__init__.py
+++ b/cancat/uds/__init__.py
@@ -442,10 +442,10 @@ class UDS(object):
         return success
 
 
-    def SecurityAccess(self, level, key = ""):
+    def SecurityAccess(self, level, secret = ""):
         """Send and receive the UDS messages to switch SecurityAccess levels.
             @level = the SecurityAccess level to switch to
-            @key = a SecurityAccess algorithm specific key
+            @secret = a SecurityAccess algorithm specific secret used to generate the key
         """
         msg = self._do_Function(SVC_SECURITY_ACCESS, subfunc=level, service = 0x67)
         if msg is None:
@@ -455,11 +455,11 @@ class UDS(object):
 
         else:
             seed = msg[2:]
-            if isinstance(key, str):
+            if isinstance(secret, str):
                 # If key is a string convert it to bytes
-                key = bytes(self._key_from_seed(seed, bytes.fromhex(key.replace(' ', ''))))
+                key = bytes(self._key_from_seed(seed, bytes.fromhex(secret.replace(' ', ''))))
             else:
-                key = bytes(self._key_from_seed(seed, key))
+                key = bytes(self._key_from_seed(seed, secret))
 
             msg = self._do_Function(SVC_SECURITY_ACCESS, subfunc=level+1, data=key, service = 0x67)
             return msg

--- a/cancat/uds/utils.py
+++ b/cancat/uds/utils.py
@@ -23,8 +23,8 @@ def get_uds_29bit_destid(arbid):
 
 def gen_uds_resp_range(arbid):
     if arbid > uds.ARBID_CONSTS['29bit']['prefix']:
-        # Normally if a request is sent to 0x18DA01F1, the response should have 
-        # an arbitration ID of 0x18DAF101, but not all ECUs do things in 
+        # Normally if a request is sent to 0x18DA01F1, the response should have
+        # an arbitration ID of 0x18DAF101, but not all ECUs do things in
         # a "normal" way, so generate a range of possible response IDs.
 
         # The src from the request will be come the destination in the response
@@ -35,8 +35,8 @@ def gen_uds_resp_range(arbid):
     else:
         # Assume this is an 11-bit request
         #
-        # Normally if a request is sent to 0x710, the response should have an 
-        # arbitration ID of 0x718, but not all ECUs do things in a "normal" way, 
+        # Normally if a request is sent to 0x710, the response should have an
+        # arbitration ID of 0x718, but not all ECUs do things in a "normal" way,
         # so generate a range of possible response IDs.
         return _range_func(0x700, 0x800)
 
@@ -91,7 +91,7 @@ def new_session(u, session, prereq_sessions=None, tester_present=False):
 def find_possible_resp(u, start_index, tx_arbid, service, subfunction=None, timeout=3.0):
     # Starting at the supplied starting index, find the service request, and
     # then look for possible responses until the supplied timeout
-    
+
     if subfunction:
         tx_match_bytes = struct.pack('>BH', service, subfunction)
         rx_match_bytes = struct.pack('>BH', service + 0x40, subfunction)
@@ -125,7 +125,7 @@ def find_possible_resp(u, start_index, tx_arbid, service, subfunction=None, time
                 (ftype == 1 and msg[2:2+match_len] == rx_match_bytes):
             return tx_msg, (arbid, msg)
 
-    return tx_msg, None 
+    return tx_msg, None
 
 
 def err_str(err):
@@ -164,15 +164,15 @@ def ecu_did_scan(c, arb_id_range, ext=0, did=0xf190, udscls=None, timeout=3.0, d
         arb_id_range, ext, did, timeout, delay))
     ecus = []
     possible_ecus = []
-    for i in arb_id_range:  
+    for i in arb_id_range:
         if ext and i == uds.ARBID_CONSTS['29bit']['tester']:
-            # Skip i == 0xF1 because in that case the sender and receiver IDs 
+            # Skip i == 0xF1 because in that case the sender and receiver IDs
             # are the same
             log.detail('Skipping 0xF1 in ext ECU scan: invalid ECU address')
             continue
         elif ext == False and i > uds.ARBID_CONSTS['11bit']['max_req_id']:
-            # For non-extended scans the valid range goes from 0x00 to 0xFF, but 
-            # stop the scan at 0xf7 because at that time the response is the 
+            # For non-extended scans the valid range goes from 0x00 to 0xFF, but
+            # stop the scan at 0xf7 because at that time the response is the
             # largest possible valid value
             log.detail('Stopping std ECU scan at 0xF7: last valid ECU address')
             break
@@ -204,7 +204,7 @@ def ecu_did_scan(c, arb_id_range, ext=0, did=0xf190, udscls=None, timeout=3.0, d
             log.debug('{} DID {}: {}'.format(addr, hex(did), e))
             log.msg('found {}'.format(addr))
 
-            # If a negative response happened, that means an ECU is present 
+            # If a negative response happened, that means an ECU is present
             # to respond at this address.
             ecus.append(addr)
 
@@ -212,7 +212,7 @@ def ecu_did_scan(c, arb_id_range, ext=0, did=0xf190, udscls=None, timeout=3.0, d
             time.sleep(delay)
 
     # Double check any non-standard responses that were found
-    for addr in possible_ecus:  
+    for addr in possible_ecus:
         u = udscls(c, addr.tx_arbid, addr.rx_arbid, extflag=addr.extflag,
                 verbose=verbose_flag, timeout=timeout)
         log.detail('Trying {}'.format(addr))
@@ -226,7 +226,7 @@ def ecu_did_scan(c, arb_id_range, ext=0, did=0xf190, udscls=None, timeout=3.0, d
             log.debug('{} DID {}: {}'.format(addr, hex(did), e))
             log.msg('found {}'.format(addr))
 
-            # If a negative response happened, that means an ECU is present 
+            # If a negative response happened, that means an ECU is present
             # to respond at this address.
             ecus.append(addr)
 
@@ -250,15 +250,15 @@ def ecu_session_scan(c, arb_id_range, ext=0, session=1, udscls=None, timeout=3.0
 
     ecus = []
     possible_ecus = []
-    for i in arb_id_range:  
+    for i in arb_id_range:
         if ext and i == uds.ARBID_CONSTS['29bit']['tester']:
-            # Skip i == 0xF1 because in that case the sender and receiver IDs 
+            # Skip i == 0xF1 because in that case the sender and receiver IDs
             # are the same
             log.detail('Skipping 0xF1 in ext ECU scan: invalid ECU address')
             continue
         elif ext == False and i > uds.ARBID_CONSTS['11bit']['max_req_id']:
-            # For non-extended scans the valid range goes from 0x00 to 0xFF, but 
-            # stop the scan at 0xf7 because at that time the response is the 
+            # For non-extended scans the valid range goes from 0x00 to 0xFF, but
+            # stop the scan at 0xf7 because at that time the response is the
             # largest possible valid value
             log.detail('Stopping std ECU scan at 0xF7: last valid ECU address')
             break
@@ -288,7 +288,7 @@ def ecu_session_scan(c, arb_id_range, ext=0, session=1, udscls=None, timeout=3.0
             log.debug('{} session {}: {}'.format(addr, session, e))
             log.msg('found {}'.format(addr))
 
-            # If a negative response happened, that means an ECU is present 
+            # If a negative response happened, that means an ECU is present
             # to respond at this address.
             ecus.append(addr)
 
@@ -296,7 +296,7 @@ def ecu_session_scan(c, arb_id_range, ext=0, session=1, udscls=None, timeout=3.0
             time.sleep(delay)
 
     # Double check any non-standard responses that were found
-    for addr in possible_ecus:  
+    for addr in possible_ecus:
         u = udscls(c, addr.tx_arbid, addr.rx_arbid, extflag=addr.extflag,
                 verbose=verbose_flag, timeout=timeout)
         log.detail('Trying {}'.format(addr))
@@ -310,7 +310,7 @@ def ecu_session_scan(c, arb_id_range, ext=0, session=1, udscls=None, timeout=3.0
             log.debug('{} session {}: {}'.format(addr, sess, e))
             log.msg('found {}'.format(addr))
 
-            # If a negative response happened, that means an ECU is present 
+            # If a negative response happened, that means an ECU is present
             # to respond at this address.
             ecus.append(addr)
 
@@ -338,7 +338,7 @@ def did_read_scan(u, did_range, delay=None):
     log.debug('Starting DID read scan for range: {}'.format(did_range))
     u.c.placeCanBookmark('did_read_scan({}, delay={})'.format(did_range, delay))
     dids = {}
-    for i in did_range:  
+    for i in did_range:
         log.detail('Trying DID read {}'.format(hex(i)))
         u.c.placeCanBookmark('ReadDID({})'.format(hex(i)))
         resp = try_read_did(u, i)
@@ -375,7 +375,7 @@ def did_write_scan(u, did_range, write_data, delay=None):
     log.debug('Starting DID write scan for range: {}'.format(did_range))
     u.c.placeCanBookmark('did_write_scan({}, write_data={}, delay={})'.format(did_range, write_data, delay))
     dids = {}
-    for i in did_range:  
+    for i in did_range:
         log.detail('Trying DID write {}'.format(hex(i)))
         u.c.placeCanBookmark('WriteDID({})'.format(hex(i)))
         resp = try_write_did(u, i, write_data)
@@ -410,7 +410,7 @@ def try_session_scan(u, session_range, prereq_sessions, found_sessions, delay=No
     log.debug('Starting session scan for range: {}'.format(session_range))
     u.c.placeCanBookmark('session_scan({}, delay={})'.format(session_range, delay))
     sessions = {}
-    for i in session_range:  
+    for i in session_range:
         # If this session matches any one of the prereqs, or one of the
         # sessions already found, skip it
         if i in prereq_sessions or i in found_sessions:
@@ -474,7 +474,7 @@ def try_session_scan(u, session_range, prereq_sessions, found_sessions, delay=No
     if recursive_scan and (try_ecu_reset or try_sess_ctrl_reset):
         subsessions = {}
         for sess in sessions:
-            # Only attempt this with sessions that we got a successful response 
+            # Only attempt this with sessions that we got a successful response
             # for
             if 'msg' in sessions[sess]:
                 log.debug('Scanning for sessions from session {} ({})'.format(sess, prereq_sessions))
@@ -493,10 +493,10 @@ def session_scan(u, session_range, delay=None, recursive_scan=True):
     return session_results
 
 
-def try_auth(u, level, key):
+def try_auth(u, level, secret):
     auth_data = None
     try:
-        resp = u.SecurityAccess(level, key)
+        resp = u.SecurityAccess(level, secret)
         if resp is not None:
             auth_data = { 'resp':resp }
     except uds.NegativeResponseException as e:
@@ -510,16 +510,16 @@ def auth_scan(u, auth_range, key_func=None, delay=None):
     log.debug('Starting auth scan for range: {}'.format(auth_range))
     u.c.placeCanBookmark('auth_scan({}, key_func={}, delay={})'.format(auth_range, key_func, delay))
     auth_levels = {}
-    for i in auth_range:  
+    for i in auth_range:
         if key_func:
-            key = ''
+            secret = ''
         else:
-            key = key_func(i)
+            secret = key_func(i)
 
-        log.detail('Trying auth level {}: key \'{}\''.format(i, key))
-        u.c.placeCanBookmark('SecurityAccess({}, {})'.format(i, repr(key)))
+        log.detail('Trying auth level {}: secret \'{}\''.format(i, secret))
+        u.c.placeCanBookmark('SecurityAccess({}, {})'.format(i, repr(secret)))
 
-        resp = try_auth(u, i, key)
+        resp = try_auth(u, i, secret)
         if resp is not None:
             log.debug('auth {}: {}'.format(i, resp))
             if 'resp' in resp:

--- a/canmap
+++ b/canmap
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 from cancat.scripts.canmap import main
 main()


### PR DESCRIPTION
A collection of fixes for things broken during the move to python3:
- Support importing saved session files created by python2 CanCat
- `UDS.StartTesterPresent`
- `UDS.StopTesterPresent` (checking if the thread is alive)
- `UDS.DiagnosticSessionControl`
- `UDS.RequestDownload`
- `UDS.SecurfityAccess`
- Restructured `UDS.SecurfityAccess` to send the seed and key to `UDS._key_from_seed` to take bytes instead of strings
- Added `UDS.RoutineControl` utility function
- fixed python version used in the top-level `canmap` script
- fixed parsing the `verbose` canmap param