### PR TITLE
Add socketcan

### DIFF
--- a/CanCat
+++ b/CanCat
@@ -48,6 +48,8 @@ if __name__ == "__main__":
     parser.add_argument('-f', '--filename', help='Load file (does not require CanCat device)')
     parser.add_argument('-I', '--interface', help='Use a predefined Interface (%s)' % interface_names)
     parser.add_argument('-S', '--baud', help='Set the CAN Bus Speed (%s)' % (baud_nums))
+    parser.add_argument('-s', '--socketcan', metavar='IFACE',
+                        help='Use socketcan interface instead of serial device (e.g., can0, vcan0)')
 
     ifo = parser.parse_args()
 
@@ -65,7 +67,8 @@ if __name__ == "__main__":
         if baud_val == None:
             raise Exception("Invalid baud: %s.  Must use one of the following: %s" % (ifo.baud, baud_nums))
 
+    transport = 'socketcan' if ifo.socketcan else 'serial'
     # TODO make a try/except block
-    results = interactive(ifo.port, intro=intro, InterfaceClass=interface, load_filename=ifo.filename, can_baud=baud_val)
+    results = interactive(ifo.port, intro=intro, InterfaceClass=interface, load_filename=ifo.filename, can_baud=baud_val, transport=transport, socketcan_iface=ifo.socketcan)
     if results == -1:
         print(colored("Error.  Try '-h' from CLI for help.", "red"))

--- a/J1939Cat
+++ b/J1939Cat
@@ -44,6 +44,8 @@ if __name__ == "__main__":
     parser.add_argument('-f', '--filename', help='Load file (does not require CanCat device)') 
     parser.add_argument('-I', '--interface', help='Use a predefined Interface (%s)' % interface_names) 
     parser.add_argument('-S', '--baud', help='Set the CAN Bus Speed (%s)' % (baud_nums)) 
+    parser.add_argument('-s', '--socketcan', metavar='IFACE',
+                        help='Use socketcan interface instead of serial device (e.g., can0, vcan0)')
 
     ifo = parser.parse_args()
 
@@ -61,6 +63,7 @@ if __name__ == "__main__":
         if baud_val == None:
             raise Exception("Invalid baud: %s.  Must use one of the following: %s" % (ifo.baud, baud_nums))
 
-    results = interactive(ifo.port, intro=intro, InterfaceClass=interface, load_filename=ifo.filename, can_baud=baud_val)
+    transport = 'socketcan' if ifo.socketcan else 'serial'
+    results = interactive(ifo.port, intro=intro, InterfaceClass=interface, load_filename=ifo.filename, can_baud=baud_val, transport=transport, socketcan_iface=ifo.socketcan)
     if results == -1:
         print("Error.  Try '-h' from CLI for help.")

--- a/cancatlib/__init__.py
+++ b/cancatlib/__init__.py
@@ -1,7 +1,3 @@
-from __future__ import print_function
-from past.builtins import xrange
-from builtins import input, bytes
-import six
 from operator import itemgetter
 
 import os
@@ -1684,11 +1680,8 @@ class CanInterface(object):
         self._send(CMD_PRINT_CAN_REGS, "")
 
     def _bytesHelper(self, msg):
-        if isinstance(msg, six.string_types):
-            if sys.version_info < (3, 0):
-                msg = bytes(msg)
-            else:
-                msg = bytes(msg, 'raw_unicode_escape')
+        if isinstance(msg, str):
+            msg = bytes(msg, 'raw_unicode_escape')
 
         return msg
 
@@ -1822,7 +1815,7 @@ class CanInTheMiddleInterface(CanInterface):
         else:
             stop = stop + 1
 
-        for idx in xrange(start, stop):
+        for idx in range(start, stop):
             ts, msg = messages[idx]
 
             arbid, data = self._splitCanMsg(msg)

--- a/cancatlib/__init__.py
+++ b/cancatlib/__init__.py
@@ -814,13 +814,29 @@ class CanInterface(object):
         if resval != 0:
             print('ISOTPxmit() failed: %s' % CAN_RESPS.get(resval))
 
-        msg, idx = self._isotp_get_msg(rx_arbid, start_index=currIdx, service=service, timeout=timeout)
+        msg, idx = self._isotp_get_msg(rx_arbid, start_index=currIdx, service=service, timeout=timeout, tx_arbid=tx_arbid)
         return msg, idx
 
-    def _isotp_get_msg(self, rx_arbid, start_index=0, service=None, timeout=None):
+    def _isotp_get_msg(self, rx_arbid, start_index=0, service=None, timeout=None, tx_arbid=None):
         '''
         Internal Method to piece together a valid ISO-TP message from received CAN packets.
+
+        For socketcan: waits for the next ISO-TP message on rx_arbid via
+        IsoTpStack -- used e.g. by UDS.xmit_recv() to wait for the real
+        response after a ResponseCorrectlyReceivedResponsePending (NRC
+        0x78). start_index is a serial/firmware-mailbox concept (a position
+        to resume scanning from) that doesn't apply here, so it's ignored.
         '''
+        if self.transport_mode == 'socketcan':
+            from cancatlib.isotp_stack import IsoTpStack
+            sub = self._transport.subscribe() if hasattr(self._transport, 'subscribe') else self._transport
+            try:
+                stack = IsoTpStack(sub, rx_id=rx_arbid, tx_id=tx_arbid)
+                msg = stack.receive(timeout=timeout or 15.0)
+            finally:
+                if sub is not self._transport and hasattr(sub, 'close'):
+                    sub.close()
+            return msg, None
 
         found = False
         complete = False

--- a/cancatlib/__init__.py
+++ b/cancatlib/__init__.py
@@ -389,6 +389,13 @@ class CanInterface(object):
         in-flight IsoTpStack transaction for frames off a single shared
         queue -- otherwise whichever of the two happened to be waiting would
         steal frames (e.g. an ISO-TP First Frame) away from the other.
+
+        Dispatches through self._cmdhandlers the same way the serial _rxtx()
+        loop does, rather than always calling _submitMessage() directly --
+        subclasses (e.g. J1939Interface) register a CMD_CAN_RECV handler to
+        get invoked live as each frame arrives (PGN/TP reassembly, myIDs
+        filtering, ...); without this, socketcan frames would only ever pile
+        up in the generic mailbox and those handlers would never run.
         '''
         sub = self._transport.subscribe() if hasattr(self._transport, 'subscribe') else self._transport
         try:
@@ -403,7 +410,13 @@ class CanInterface(object):
                     arbid, data_bytes, extflag = frame
                     ts = time.time()
                     msg = struct.pack('>I', arbid) + data_bytes
-                    self._submitMessage(CMD_CAN_RECV, (ts, msg))
+                    tsmsg = (ts, msg)
+
+                    cmdhandler = self._cmdhandlers.get(CMD_CAN_RECV)
+                    if cmdhandler is not None:
+                        cmdhandler(tsmsg, self)
+                    else:
+                        self._submitMessage(CMD_CAN_RECV, tsmsg)
                 except Exception as e:
                     if not self._config['shutdown']:
                         print("SocketCAN rx error: %r" % e)

--- a/cancatlib/__init__.py
+++ b/cancatlib/__init__.py
@@ -220,20 +220,25 @@ DONT_PRINT_THIS_MESSAGE = SPECIAL_CASE
 class CanInterface(object):
     _msg_source_idx = CMD_CAN_RECV
 
-    def __init__(self, port=None, baud=baud, verbose=False, cmdhandlers=None, comment='', load_filename=None, orig_iface=None, max_msgs=None):
+    def __init__(self, port=None, baud=baud, verbose=False, cmdhandlers=None, comment='', load_filename=None, orig_iface=None, max_msgs=None, transport='serial', socketcan_iface=None):
         '''
         CAN Analysis Workspace
         This can be subclassed by vendor to allow more vendor-specific code
         based on the way each vendor uses the varios Buses
+
+        Args:
+            ... (existing args unchanged)
+            transport: 'serial' or 'socketcan'. Default 'serial' for backward compat.
+            socketcan_iface: Interface name for socketcan mode (e.g., 'vcan0', 'can0').
         '''
         if orig_iface != None:
             self._consumeInterface(orig_iface)
             return
 
 
-        self.init(port, baud, verbose, cmdhandlers, comment, load_filename, orig_iface, max_msgs)
+        self.init(port, baud, verbose, cmdhandlers, comment, load_filename, orig_iface, max_msgs, transport=transport, socketcan_iface=socketcan_iface)
 
-    def init(self, port=None, baud=baud, verbose=False, cmdhandlers=None, comment='', load_filename=None, orig_iface=None, max_msgs=None):
+    def init(self, port=None, baud=baud, verbose=False, cmdhandlers=None, comment='', load_filename=None, orig_iface=None, max_msgs=None, transport='serial', socketcan_iface=None):
         self._inbuf = b''
         self._trash = []
         self._messages = {}
@@ -248,6 +253,21 @@ class CanInterface(object):
         self.port = self._config['port'] = port
         self._baud = self._config['baud'] = baud
         self.name = self._config['name'] = 'CanCat'
+        self.transport_mode = self._config['transport'] = transport
+
+        # --- Transport layer setup (Step 3.2) -----------------------------------
+        self._transport = None
+        if transport == 'serial':
+            pass  # legacy path: _io is set by _reconnect() below
+        elif transport == 'socketcan':
+            from .transport import SocketcanTransport
+            iface = socketcan_iface or 'vcan0'
+            self._transport = SocketcanTransport(channel=iface)
+            self._transport.open()
+        else:
+            raise ValueError(f"Unsupported transport mode: {transport!r}")
+        # -----------------------------------------------------------------------
+
         self._io = None
         self._in_lock = None
         self._out_lock = None
@@ -268,19 +288,28 @@ class CanInterface(object):
         #### FIXME: make this a connection cycle, not just a "pick the first one" thing...
         #### Prove that it's a CanCat... and that it's not in use by something else...
         # If we specify a file and no port, assume we just want to read the file, only try to guess
-        # ports if there is no file specified
+         # ports if there is no file specified
         if self.port == None and load_filename == None:
-            self.port = getDeviceFile()
+            if transport == 'socketcan':
+                pass  # socketcan has its own initialization above; port is not needed
+            else:
+                self.port = getDeviceFile()
 
-        # No filename, can't guess the port, whatcha gonna do?
-        if self.port == None and load_filename == None:
+        # No filename, can't guess the port, whatcha gonna do? (serial only)
+        if self.port == None and load_filename == None and transport != 'socketcan':
             raise Exception("Cannot find device, and no filename specified.  Please try again.")
 
-        if self.port != None:
-            self._reconnect()
+        if self.port != None or transport == 'socketcan':
+            # Serial path only: reconnect and start rx thread
+            if transport == 'serial' and self.port != None:
+                self._reconnect()
 
-            # just start the receive thread, it's lightweight and you never know when you may want it.
-            self._startRxThread()
+                # just start the receive thread, it's lightweight and you never know when you may want it.
+                self._startRxThread()
+            elif transport == 'socketcan':
+                # Start a background thread to read CAN frames from socketcan and enqueue them
+                _thread = threading.Thread(target=self.__class__._socketcan_rx_loop, args=(self,), daemon=True)
+                _thread.start()
         self._config['go'] = True
 
     def _startRxThread(self):
@@ -347,9 +376,33 @@ class CanInterface(object):
         if self._io and isinstance(self._io, serial.Serial):
             print("shutting down serial connection")
             self._io.close()
+        # Close transport layer (Step 3.6)
+        if self._transport is not None:
+            self._transport.close()
         self._config['shutdown'] = True
         if self._commsthread != None:
             self._commsthread.wait()
+
+    def _socketcan_rx_loop(self):
+        '''
+        Background thread for socketcan transport. Reads CAN frames from the
+        transport layer and submits them to the CMD_CAN_RECV mailbox.
+        '''
+        while not self._config['shutdown']:
+            if not self._transport:
+                time.sleep(0.1)
+                continue
+            try:
+                frame = self._transport.recv_raw_can(timeout=1.0)
+                if frame is None:
+                    continue
+                arbid, data_bytes, extflag = frame
+                ts = time.time()
+                msg = struct.pack('>I', arbid) + data_bytes
+                self._submitMessage(CMD_CAN_RECV, (ts, msg))
+            except Exception as e:
+                if not self._config['shutdown']:
+                    print("SocketCAN rx error: %r" % e)
 
     def clearCanMsgs(self):
         '''
@@ -589,44 +642,65 @@ class CanInterface(object):
 
         for x in range(count):
             yield self.recv(CMD_CAN_RECV)
-
     def CANxmit(self, arbid, message, extflag=0, timeout=3, count=1):
         '''
-        Transmit a CAN message on the attached CAN bus
-        Currently returns the *last* result
+        Transmit a CAN message on the attached CAN bus.
+        Currently returns the *last* result.
+
+        For serial transport: uses CanCat protocol commands (CMD_CAN_SEND).
+        For socketcan transport: sends via python-can, returns 0 (success).
         '''
 
+        if self.transport_mode == 'socketcan':
+            # SocketCAN path -- direct send through transport layer
+            for i in range(count):
+                result = self._transport.send_raw_can(arbid, message, extflag=bool(extflag))
+            return 0  # success -- no handshake needed on socketcan
+
+        # Serial path: pack full protocol message and go through existing logic
         msg = struct.pack('>I', arbid) + struct.pack('B', extflag) + self._bytesHelper(message)
 
         for i in range(count):
             self._send(CMD_CAN_SEND, msg)
             ts, result = self.recv(CMD_CAN_SEND_RESULT, timeout)
 
-        if result == None:
+        if result is None:
             print("CANxmit:  Return is None!?")
             return None
 
         resval = ord(result)
-        if resval != 0:
-            print("CANxmit() failed: %s" % CAN_RESPS.get(resval))
+        if CAN_RESPS.get(resval):
+            print(f"CANxmit failed with code {resval}: {CAN_RESPS[resval]}")
 
         return resval
+
 
     def ISOTPxmit(self, tx_arbid, rx_arbid, message, extflag=0, timeout=3, count=1):
         '''
         Transmit an ISOTP can message. tx_arbid is the arbid we're transmitting,
-        and rx_arbid is the arbid we're listening for
+        and rx_arbid is the arbid we're listening for.
+
+        For socketcan transport: uses IsoTpStack (Python-layer) for flow control.
+        For serial transport: delegates to CanCat firmware via CMD_CAN_SEND_ISOTP.
         '''
+
+        if self.transport_mode == 'socketcan':
+            from cancatlib.isotp_stack import IsoTpStack
+            stack = IsoTpStack(self._transport, rx_id=rx_arbid, tx_id=tx_arbid)
+            for i in range(count):
+                result = stack.send(tx_arbid, message, extflag=bool(extflag))
+            return 0 if result else 1
+
         msg = struct.pack('>IIB', tx_arbid, rx_arbid, extflag) + message
         for i in range(count):
             self._send(CMD_CAN_SEND_ISOTP, msg)
             ts, result = self.recv(CMD_CAN_SEND_ISOTP_RESULT, timeout)
 
-        if result == None:
-            print("ISOTPxmit: Return is None!?")
+        if result is None:
+            print('ISOTPxmit: Return is None!?')
         resval = ord(result)
         if resval != 0:
-            print("ISOTPxmit() failed: %s" % CAN_RESPS.get(resval))
+            print('ISOTPxmit() failed: %s' % CAN_RESPS.get(resval))
 
         return resval
 
@@ -647,25 +721,48 @@ class CanInterface(object):
 
         return msg
 
-    def _isotp_enable_flowcontrol(self, tx_arbid, rx_arbid, extflag, timeout=3):
+    def _isotp_enable_flowcontrol(self, tx_arbid, rx_arbid, extflag=0, timeout=3):
+        '''
+        Enable ISO-TP flow control. For socketcan mode this is a no-op
+        because IsoTpStack handles FC frames inline during receive.
+        For serial transport: tells CanCat firmware to send FC on rx_arbid.
+        '''
+
+        if self.transport_mode == 'socketcan':
+            # Handled by IsoTpStack during receive(); nothing to pre-enable
+            return 0
+
         msg = struct.pack('>IIB', tx_arbid, rx_arbid, extflag)
         self._send(CMD_CAN_RECV_ISOTP, msg)
         ts, result = self.recv(CMD_CAN_RECV_ISOTP_RESULT, timeout)
 
-        if result == None:
-            print("_isotp_enable_flowcontrol: Return is None!?")
+        if result is None:
+            print('_isotp_enable_flowcontrol: Return is None!?')
         resval = ord(result)
         if resval != 0:
-            print("_isotp_enable_flowcontrol() failed: %s" % CAN_RESPS.get(resval))
+            print('_isotp_enable_flowcontrol() failed: %s' % CAN_RESPS.get(resval))
 
         return resval
 
+
     def ISOTPxmit_recv(self, tx_arbid, rx_arbid, message, extflag=0, timeout=3, count=1, service=None):
         '''
-        Transmit an ISOTP can message, then wait for a response.
+        Transmit an ISO-TP can message, then wait for a response.
         tx_arbid is the arbid we're transmitting, and rx_arbid
-        is the arbid we're listening for
+        is the arbid we're listening for.
+
+        For socketcan: uses IsoTpStack to send + receive.
+        For serial: delegates to CanCat firmware via CMD_CAN_SENDRECV_ISOTP.
         '''
+
+        if self.transport_mode == 'socketcan':
+            from cancatlib.isotp_stack import IsoTpStack
+            stack = IsoTpStack(self._transport, rx_id=rx_arbid, tx_id=tx_arbid)
+            for i in range(count):
+                result = stack.send(tx_arbid, message, extflag=bool(extflag))
+            # Now receive response
+            resp_data = stack.receive(timeout=min(timeout * 2, 15.0))
+            return resp_data, None
 
         currIdx = self.getCanMsgCount()
         msg = struct.pack('>II', tx_arbid, rx_arbid) + struct.pack('B', extflag) + self._bytesHelper(message)
@@ -673,13 +770,13 @@ class CanInterface(object):
             self._send(CMD_CAN_SENDRECV_ISOTP, msg)
             ts, result = self.recv(CMD_CAN_SENDRECV_ISOTP_RESULT, timeout)
 
-        if result == None:
-            print("ISOTPxmit: Return is None!?")
+        if result is None:
+            print('ISOTPxmit: Return is None!?')
         resval = ord(result)
         if resval != 0:
-            print("ISOTPxmit() failed: %s" % CAN_RESPS.get(resval))
+            print('ISOTPxmit() failed: %s' % CAN_RESPS.get(resval))
 
-        msg, idx = self._isotp_get_msg(rx_arbid, start_index = currIdx, service = service, timeout = timeout)
+        msg, idx = self._isotp_get_msg(rx_arbid, start_index=currIdx, service=service, timeout=timeout)
         return msg, idx
 
     def _isotp_get_msg(self, rx_arbid, start_index=0, service=None, timeout=None):

--- a/cancatlib/__init__.py
+++ b/cancatlib/__init__.py
@@ -2294,7 +2294,6 @@ cs = []
 
 
 def cleanupInteractiveAtExit():
-    global cs
     for c in cs:
         try:
             c.__del__()

--- a/cancatlib/__init__.py
+++ b/cancatlib/__init__.py
@@ -383,22 +383,33 @@ class CanInterface(object):
         '''
         Background thread for socketcan transport. Reads CAN frames from the
         transport layer and submits them to the CMD_CAN_RECV mailbox.
+
+        Uses its own subscription (see SocketcanTransport.subscribe()) so it
+        gets a private copy of every frame instead of competing with an
+        in-flight IsoTpStack transaction for frames off a single shared
+        queue -- otherwise whichever of the two happened to be waiting would
+        steal frames (e.g. an ISO-TP First Frame) away from the other.
         '''
-        while not self._config['shutdown']:
-            if not self._transport:
-                time.sleep(0.1)
-                continue
-            try:
-                frame = self._transport.recv_raw_can(timeout=1.0)
-                if frame is None:
+        sub = self._transport.subscribe() if hasattr(self._transport, 'subscribe') else self._transport
+        try:
+            while not self._config['shutdown']:
+                if not self._transport:
+                    time.sleep(0.1)
                     continue
-                arbid, data_bytes, extflag = frame
-                ts = time.time()
-                msg = struct.pack('>I', arbid) + data_bytes
-                self._submitMessage(CMD_CAN_RECV, (ts, msg))
-            except Exception as e:
-                if not self._config['shutdown']:
-                    print("SocketCAN rx error: %r" % e)
+                try:
+                    frame = sub.recv_raw_can(timeout=1.0)
+                    if frame is None:
+                        continue
+                    arbid, data_bytes, extflag = frame
+                    ts = time.time()
+                    msg = struct.pack('>I', arbid) + data_bytes
+                    self._submitMessage(CMD_CAN_RECV, (ts, msg))
+                except Exception as e:
+                    if not self._config['shutdown']:
+                        print("SocketCAN rx error: %r" % e)
+        finally:
+            if sub is not self._transport and hasattr(sub, 'close'):
+                sub.close()
 
     def clearCanMsgs(self):
         '''
@@ -682,9 +693,18 @@ class CanInterface(object):
 
         if self.transport_mode == 'socketcan':
             from cancatlib.isotp_stack import IsoTpStack
-            stack = IsoTpStack(self._transport, rx_id=rx_arbid, tx_id=tx_arbid)
-            for i in range(count):
-                result = stack.send(tx_arbid, message, extflag=bool(extflag))
+            # Use a private subscription so this transaction's FC/CF frames
+            # aren't stolen by (or steal from) the background logging
+            # thread reading off the same transport -- see
+            # SocketcanTransport.subscribe().
+            sub = self._transport.subscribe() if hasattr(self._transport, 'subscribe') else self._transport
+            try:
+                stack = IsoTpStack(sub, rx_id=rx_arbid, tx_id=tx_arbid)
+                for i in range(count):
+                    result = stack.send(tx_arbid, message, extflag=bool(extflag))
+            finally:
+                if sub is not self._transport and hasattr(sub, 'close'):
+                    sub.close()
             return 0 if result else 1
 
         msg = struct.pack('>IIB', tx_arbid, rx_arbid, extflag) + message
@@ -753,11 +773,20 @@ class CanInterface(object):
 
         if self.transport_mode == 'socketcan':
             from cancatlib.isotp_stack import IsoTpStack
-            stack = IsoTpStack(self._transport, rx_id=rx_arbid, tx_id=tx_arbid)
-            for i in range(count):
-                result = stack.send(tx_arbid, message, extflag=bool(extflag))
-            # Now receive response
-            resp_data = stack.receive(timeout=min(timeout * 2, 15.0))
+            # Use a private subscription so this transaction's FF/CF/FC
+            # frames aren't stolen by (or steal from) the background
+            # logging thread reading off the same transport -- see
+            # SocketcanTransport.subscribe().
+            sub = self._transport.subscribe() if hasattr(self._transport, 'subscribe') else self._transport
+            try:
+                stack = IsoTpStack(sub, rx_id=rx_arbid, tx_id=tx_arbid)
+                for i in range(count):
+                    result = stack.send(tx_arbid, message, extflag=bool(extflag))
+                # Now receive response
+                resp_data = stack.receive(timeout=min(timeout * 2, 15.0), extflag=bool(extflag))
+            finally:
+                if sub is not self._transport and hasattr(sub, 'close'):
+                    sub.close()
             return resp_data, None
 
         currIdx = self.getCanMsgCount()
@@ -936,7 +965,16 @@ class CanInterface(object):
         '''
         set the baud rate for the CAN bus.  this has nothing to do with the
         connection from the computer to the tool
+
+        This is only meaningful for the custom CanCat firmware, which has to
+        be told what speed to run the CAN bus at.  A socketcan interface is
+        configured externally (e.g. via `ip link set can0 up type can
+        bitrate ...`) before CanCat ever touches it, so there is no firmware
+        to talk to and this is a no-op in that mode.
         '''
+        if self.transport_mode == 'socketcan':
+            self._config['can_baud'] = baud_const
+            return
 
         baud = struct.pack("B", baud_const)
 

--- a/cancatlib/__init__.py
+++ b/cancatlib/__init__.py
@@ -2414,11 +2414,11 @@ def getDeviceFile():
             return port
 
 
-def interactive(port=None, InterfaceClass=CanInterface, intro='', load_filename=None, can_baud=None):
+def interactive(port=None, InterfaceClass=CanInterface, intro='', load_filename=None, can_baud=None, transport='serial', socketcan_iface=None):
     global c
     import atexit
 
-    c = InterfaceClass(port=port, load_filename=load_filename)
+    c = InterfaceClass(port=port, load_filename=load_filename, transport=transport, socketcan_iface=socketcan_iface)
     atexit.register(cleanupInteractiveAtExit)
 
     if load_filename is None:

--- a/cancatlib/ccp/utils.py
+++ b/cancatlib/ccp/utils.py
@@ -1,6 +1,4 @@
 import struct
-import six
-import sys
 
 '''
 Table of Command Codes
@@ -119,13 +117,7 @@ def _gen_byte(value):
 
 
 def _parse_byte(value):
-    if isinstance(value, six.string_types):
-        if sys.version_info < (3, 0):
-            return struct.unpack('B', value)[0]
-        else:
-            return value
-    else:
-        return value
+    return value
 
 
 def _gen_2_byte_val(value):
@@ -154,18 +146,9 @@ def _parse_4_byte_value(value):
 
 
 def _parse_6_byte_value(value):
-    if isinstance(value, six.string_types):
-        if sys.version_info < (3, 0):
-            return '0x' + value.encode('hex')
-        else:
-            return '0x' + value.hex()
-    else:
-        return '0x' + value.hex()
+    return '0x' + value.hex()
 
 
 def _bytesHelper(msg):
-    if isinstance(msg, six.string_types):
-        if sys.version_info < (3, 0):
-            return bytes(msg)
-        else:
-            return bytes(msg, 'raw_unicode_escape')
+    if isinstance(msg, str):
+        return bytes(msg, 'raw_unicode_escape')

--- a/cancatlib/iso_tp.py
+++ b/cancatlib/iso_tp.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import sys
 import struct
 

--- a/cancatlib/isotp_stack.py
+++ b/cancatlib/isotp_stack.py
@@ -1,0 +1,194 @@
+"""ISO-TP (ISO 15765-2) stack implemented in the Python layer.
+
+Provides multi-frame message assembly/disassembly with flow control for
+SocketCAN mode, where the underlying kernel does not handle ISO-TP natively.
+
+Used by CanCat when communicating via SocketCAN to send and receive ECU
+messages larger than 8 bytes (UDS diagnostic requests/responses).
+"""
+from __future__ import print_function
+import struct
+import sys
+import threading
+import time
+
+
+# ---------------------------------------------------------------------------
+# ISO-TP constants
+# ---------------------------------------------------------------------------
+
+ISO_TP_SA    = 0x00   # Single Frame indicator bit position (bits 7-6)
+ISO_TP_FF    = 0x10   # First Frame indicator
+ISO_TP_FC    = 0x20   # Flow Control indicator
+ISO_TP_CF    = 0x30   # Consecutive Frame indicator
+ISO_TP_TS_MASK = 0x0F # Reserved byte / timestamp mask
+
+# Single frame maximum payload (5 bytes type + data)
+ISO_TP_SF_MAX_DL = 6
+
+# Flow control status values
+ISO_TP_FC_CONTINUE       = 0x00
+ISO_TP_FC_WAIT           = 0x01
+ISO_TP_FC_OVERFLOW_ERROR = 0x02
+
+# Default flow control parameters
+ISO_TP_DS_SEP_DEFAULT    = 0x00   # min. 0 ms between CFs
+ISO_TP_BS_DEFAULT        = 0x80   # block size 0 (unlimited)
+
+
+class IsoTpStack(object):
+    """Python-layer ISO-TP stack for SocketCAN transport.
+
+    Handles multi-frame send/receive with flow control negotiation.  Wraps a
+    :class:`Transport` instance that provides ``send_raw_can`` and
+    ``recv_raw_can`` for single 8-byte CAN frames.
+    """
+
+    def __init__(self, transport, rx_id=None, tx_id=None):
+        self._transport = transport
+        self._rx_id = rx_id or 0x7DF   # standard OBD-UAS receiver
+        self._tx_id = tx_id or 0x7E8   # default ECU response address
+        self._fc_bs = ISO_TP_BS_DEFAULT
+        self._fc_st_min = ISO_TP_DS_SEP_DEFAULT
+        self._lock = threading.Lock()
+
+    def send(self, arbid, data, extflag=False):
+        """Send a (potentially > 8 byte) ISO-TP message.
+
+        Returns ``True`` on success or ``False`` if the ECU responds with an error.
+        """
+        total_len = len(data)
+        if total_len <= ISO_TP_SF_MAX_DL:
+            # -- Single Frame --------------------------------------------------
+            header = struct.pack("B", ISO_TP_SA | total_len)
+            frame_data = header + data[:total_len]
+            self._transport.send_raw_can(arbid, frame_data, extflag=extflag)
+            return True
+
+        # -- Multi-Frame: First Frame ------------------------------------------
+        ff_header = struct.pack("!BH", ISO_TP_FF, total_len)
+        ff_payload = ff_header + data[:6]
+        self._transport.send_raw_can(arbid, ff_payload, extflag=extflag)
+
+        # -- Send Consecutive Frames, respecting flow control ------------------
+        offset = 6
+        block_count = 0
+        sn = 1  # sequence number starts at 1 for CF[1]
+
+        while offset < total_len:
+            # Wait for next FC before sending more (ECU may send FC)
+            resp = self._transport.recv_raw_can(timeout=2.0)
+
+            if resp is not None:
+                arbid_r, frame_data, extflag_r = resp
+                fc_status = self._parse_flow_control(frame_data)
+                if fc_status == ISO_TP_FC_OVERFLOW_ERROR:
+                    print("ISO-TP flow control overflow error", file=sys.stderr)
+                    return False
+                elif fc_status == ISO_TP_FC_WAIT:
+                    # Wait before continuing
+                    continue
+
+            # Send Consecutive Frame
+            cf_header = struct.pack("B", ISO_TP_CF | (sn & 0x0F))
+            cf_payload = cf_header + data[offset:offset + 7]
+            self._transport.send_raw_can(arbid, cf_payload, extflag=extflag)
+
+            offset += 7
+            sn = (sn + 1) & 0x0F
+            block_count += 1
+
+            # Block size check -- must wait for FC if BS is set
+            if self._fc_bs != 0 and block_count >= self._fc_bs:
+                block_count = 0
+
+            # Inter-frame delay (STmin conversion)
+            st_min_us = self._st_min_to_us(self._fc_st_min or 0)
+            if st_min_us > 0:
+                time.sleep(st_min_us / 1e6)
+
+        return True
+
+    def receive(self, timeout=5.0):
+        """Wait for and assemble an incoming ISO-TP message.
+
+        Returns ``None`` on timeout. Otherwise returns raw response data bytes.
+        """
+        first_frame = self._transport.recv_raw_can(timeout=timeout)
+        if first_frame is None:
+            return None
+
+        arbid, frame_data, extflag = first_frame
+        pci_byte = frame_data[0]
+        pci_type = (pci_byte & 0xF0) >> 4
+
+        if pci_type == 0x0:
+            # -- Single Frame --------------------------------------------------
+            length = pci_byte & 0x0F
+            return frame_data[1:length + 1]
+
+        elif pci_type == 0x1:
+            # -- First Frame (multi-frame) ------------------------------------
+            total_length = struct.unpack("!H", frame_data[1:3])[0]
+            accumulated = bytearray(frame_data[3:])  # first 6 bytes of data
+
+            sn = 0  # expected sequence number for next CF
+
+            while len(accumulated) < total_length:
+                cf_frame = self._transport.recv_raw_can(timeout=2.0)
+                if cf_frame is None:
+                    break
+                _, cf_data, _ = cf_frame
+                cf_sn = cf_data[0] & 0x0F
+
+                if cf_sn != sn:
+                    print("ISO-TP consecutive frame sequence error", file=sys.stderr)
+                    return None
+
+                accumulated += cf_data[1:]   # append payload bytes (7 max per CF)
+                sn = (sn + 1) & 0x0F
+
+            else:
+                return bytes(accumulated[:total_length])
+
+        elif pci_type == 0x3:
+            # -- Response to a request the ECU sent to us; send FC --------------
+            self._send_flow_control()
+
+    def _parse_flow_control(self, frame_data):
+        """Parse and extract flow control parameters.
+
+        Returns the status code (CONTINUE/WAIT/OVERFLOW_ERROR).
+        """
+        try:
+            status_code = frame_data[0] & 0x0F
+            bs = frame_data[1]
+            st_min_raw = frame_data[2]
+        except IndexError:
+            return ISO_TP_FC_OVERFLOW_ERROR
+
+        self._fc_bs = bs
+        if st_min_raw <= 0x7F:
+            self._fc_st_min = st_min_raw    # ms value
+        elif st_min_raw >= 0xF1 and st_min_raw <= 0xF9:
+            self._fc_st_min = st_min_raw - 0xF1 + 100   # map to centiseconds
+
+        return status_code
+
+    def _st_min_to_us(self, raw):
+        """Convert STmin byte value to microseconds."""
+        if raw == 0:
+            return 0
+        elif raw <= 0x7F:
+            return int(raw * 1e3)      # ms -> us
+        elif raw >= 0xF1 and raw <= 0xF9:
+            centiseconds = (raw - 0xF1 + 100)
+            return int(centiseconds * 10e3)   # cs to us
+
+    def _send_flow_control(self):
+        """Send a Flow Control message back to the ECU."""
+        fc_frame = struct.pack("BBB",
+                               ISO_TP_FC | ISO_TP_FC_CONTINUE,
+                               self._fc_bs,                 # block size
+                               self._fc_st_min              # STmin
+                              )[:8]  # pad to 8 bytes for CAN frame

--- a/cancatlib/isotp_stack.py
+++ b/cancatlib/isotp_stack.py
@@ -6,7 +6,6 @@ SocketCAN mode, where the underlying kernel does not handle ISO-TP natively.
 Used by CanCat when communicating via SocketCAN to send and receive ECU
 messages larger than 8 bytes (UDS diagnostic requests/responses).
 """
-from __future__ import print_function
 import struct
 import sys
 import threading

--- a/cancatlib/isotp_stack.py
+++ b/cancatlib/isotp_stack.py
@@ -81,28 +81,20 @@ class IsoTpStack(object):
         ff_payload = ff_header + first_chunk
         self._transport.send_raw_can(arbid, ff_payload, extflag=extflag)
 
-        # -- Send Consecutive Frames, respecting flow control ------------------
+        # -- Wait for the initial Flow Control before sending any CFs ----------
+        # Per ISO 15765-2 a Flow Control frame is only expected once per
+        # block: BS (block size) CFs get sent back-to-back (paced by STmin),
+        # and another FC is only awaited after a full block -- not before
+        # every single CF. BS==0 means "no limit", i.e. send everything and
+        # never wait for another FC.
+        if not self._await_flow_control(timeout=2.0):
+            return False
+
+        # -- Send Consecutive Frames, respecting the negotiated block size -----
         block_count = 0
         sn = 1  # sequence number starts at 1 for CF[1]
 
         while offset < total_len:
-            # Wait for the ECU's Flow Control frame before sending more.
-            resp = self._recv_from_ecu(timeout=2.0)
-
-            if resp is not None:
-                arbid_r, frame_data, extflag_r = resp
-                fc_status = self._parse_flow_control(frame_data)
-                if fc_status == ISO_TP_FC_OVERFLOW_ERROR:
-                    print("ISO-TP flow control overflow error", file=sys.stderr)
-                    return False
-                elif fc_status == ISO_TP_FC_WAIT:
-                    # Wait before continuing
-                    continue
-            else:
-                print("ISO-TP: timed out waiting for Flow Control", file=sys.stderr)
-                return False
-
-            # Send Consecutive Frame
             cf_header = struct.pack("B", ISO_TP_CF | (sn & 0x0F))
             cf_payload = cf_header + data[offset:offset + 7]
             self._transport.send_raw_can(arbid, cf_payload, extflag=extflag)
@@ -111,16 +103,56 @@ class IsoTpStack(object):
             sn = (sn + 1) & 0x0F
             block_count += 1
 
-            # Block size check -- must wait for FC if BS is set
-            if self._fc_bs != 0 and block_count >= self._fc_bs:
-                block_count = 0
-
             # Inter-frame delay (STmin conversion)
             st_min_us = self._st_min_to_us(self._fc_st_min or 0)
             if st_min_us > 0:
                 time.sleep(st_min_us / 1e6)
 
+            # Block size check -- only wait for another FC once we've sent
+            # a full block (and there's more data left to send).
+            if self._fc_bs != 0 and block_count >= self._fc_bs and offset < total_len:
+                block_count = 0
+                if not self._await_flow_control(timeout=2.0):
+                    return False
+
         return True
+
+    def _await_flow_control(self, timeout=2.0):
+        """Wait for a Flow Control frame, updating self._fc_bs/_fc_st_min.
+
+        Ignores anything on our rx id that isn't actually PCI-type Flow
+        Control (0x3) -- e.g. a negative response left over from a prior
+        request, or other traffic -- rather than misparsing it as one; that
+        traffic doesn't consume the wait budget for the FC we're actually
+        after. Loops on repeated FC_WAIT frames (the ECU asking for more
+        time before it's ready for the next block/CF), each restarting the
+        wait budget since the ECU explicitly asked for more time. Returns
+        True once a CONTINUE is received; False on timeout or overflow, in
+        which case the caller should abort the transfer.
+        """
+        while True:
+            deadline = time.time() + timeout
+            while True:
+                remaining = deadline - time.time()
+                if remaining <= 0:
+                    print("ISO-TP: timed out waiting for Flow Control", file=sys.stderr)
+                    return False
+                resp = self._recv_from_ecu(timeout=remaining)
+                if resp is None:
+                    print("ISO-TP: timed out waiting for Flow Control", file=sys.stderr)
+                    return False
+                _, frame_data, _ = resp
+                if ((frame_data[0] & 0xF0) >> 4) == 0x3:
+                    break
+                # not a Flow Control frame -- ignore and keep waiting
+
+            fc_status = self._parse_flow_control(frame_data)
+            if fc_status == ISO_TP_FC_OVERFLOW_ERROR:
+                print("ISO-TP flow control overflow error", file=sys.stderr)
+                return False
+            if fc_status == ISO_TP_FC_CONTINUE:
+                return True
+            # else FC_WAIT -- loop and wait for the next FC (fresh budget)
 
     def receive(self, timeout=5.0, extflag=False):
         """Wait for and assemble an incoming ISO-TP message.

--- a/cancatlib/isotp_stack.py
+++ b/cancatlib/isotp_stack.py
@@ -13,13 +13,13 @@ import time
 
 
 # ---------------------------------------------------------------------------
-# ISO-TP constants
+# ISO-TP constants (ISO 15765-2 PCI type nibble, top 4 bits of byte 0)
 # ---------------------------------------------------------------------------
 
 ISO_TP_SA    = 0x00   # Single Frame indicator bit position (bits 7-6)
 ISO_TP_FF    = 0x10   # First Frame indicator
-ISO_TP_FC    = 0x20   # Flow Control indicator
-ISO_TP_CF    = 0x30   # Consecutive Frame indicator
+ISO_TP_CF    = 0x20   # Consecutive Frame indicator
+ISO_TP_FC    = 0x30   # Flow Control indicator
 ISO_TP_TS_MASK = 0x0F # Reserved byte / timestamp mask
 
 # Single frame maximum payload (5 bytes type + data)
@@ -45,8 +45,8 @@ class IsoTpStack(object):
 
     def __init__(self, transport, rx_id=None, tx_id=None):
         self._transport = transport
-        self._rx_id = rx_id or 0x7DF   # standard OBD-UAS receiver
-        self._tx_id = tx_id or 0x7E8   # default ECU response address
+        self._rx_id = rx_id or 0x7DF   # arbid we expect the ECU to respond on
+        self._tx_id = tx_id or 0x7E8   # arbid we transmit our own frames on
         self._fc_bs = ISO_TP_BS_DEFAULT
         self._fc_st_min = ISO_TP_DS_SEP_DEFAULT
         self._lock = threading.Lock()
@@ -65,18 +65,29 @@ class IsoTpStack(object):
             return True
 
         # -- Multi-Frame: First Frame ------------------------------------------
-        ff_header = struct.pack("!BH", ISO_TP_FF, total_len)
-        ff_payload = ff_header + data[:6]
+        # ISO 15765-2 packs the length into a 2-byte PCI: the top nibble of
+        # byte 0 is the FF type, the bottom nibble + all of byte 1 hold a
+        # 12-bit length (0-4095), leaving 6 data bytes in the 8-byte frame.
+        # Lengths beyond 4095 use the "escape" form: byte 0/1 = 0x10 0x00
+        # followed by a 4-byte length, leaving only 2 data bytes.
+        if total_len <= 0xFFF:
+            ff_header = struct.pack("BB", ISO_TP_FF | ((total_len >> 8) & 0x0F), total_len & 0xFF)
+            first_chunk = data[:6]
+            offset = 6
+        else:
+            ff_header = struct.pack(">BBI", ISO_TP_FF, 0x00, total_len)
+            first_chunk = data[:2]
+            offset = 2
+        ff_payload = ff_header + first_chunk
         self._transport.send_raw_can(arbid, ff_payload, extflag=extflag)
 
         # -- Send Consecutive Frames, respecting flow control ------------------
-        offset = 6
         block_count = 0
         sn = 1  # sequence number starts at 1 for CF[1]
 
         while offset < total_len:
-            # Wait for next FC before sending more (ECU may send FC)
-            resp = self._transport.recv_raw_can(timeout=2.0)
+            # Wait for the ECU's Flow Control frame before sending more.
+            resp = self._recv_from_ecu(timeout=2.0)
 
             if resp is not None:
                 arbid_r, frame_data, extflag_r = resp
@@ -87,6 +98,9 @@ class IsoTpStack(object):
                 elif fc_status == ISO_TP_FC_WAIT:
                     # Wait before continuing
                     continue
+            else:
+                print("ISO-TP: timed out waiting for Flow Control", file=sys.stderr)
+                return False
 
             # Send Consecutive Frame
             cf_header = struct.pack("B", ISO_TP_CF | (sn & 0x0F))
@@ -108,16 +122,16 @@ class IsoTpStack(object):
 
         return True
 
-    def receive(self, timeout=5.0):
+    def receive(self, timeout=5.0, extflag=False):
         """Wait for and assemble an incoming ISO-TP message.
 
         Returns ``None`` on timeout. Otherwise returns raw response data bytes.
         """
-        first_frame = self._transport.recv_raw_can(timeout=timeout)
+        first_frame = self._recv_from_ecu(timeout=timeout)
         if first_frame is None:
             return None
 
-        arbid, frame_data, extflag = first_frame
+        arbid, frame_data, frame_extflag = first_frame
         pci_byte = frame_data[0]
         pci_type = (pci_byte & 0xF0) >> 4
 
@@ -128,19 +142,36 @@ class IsoTpStack(object):
 
         elif pci_type == 0x1:
             # -- First Frame (multi-frame) ------------------------------------
-            total_length = struct.unpack("!H", frame_data[1:3])[0]
-            accumulated = bytearray(frame_data[3:])  # first 6 bytes of data
+            # 2-byte PCI: 12-bit length in (byte0 low nibble, byte1); a
+            # length of 0 there means the escape form -- a 4-byte length
+            # follows in bytes 2-5, leaving only 2 data bytes (see send()).
+            ff_dl = ((pci_byte & 0x0F) << 8) | frame_data[1]
+            if ff_dl == 0:
+                total_length = struct.unpack(">I", frame_data[2:6])[0]
+                accumulated = bytearray(frame_data[6:])
+            else:
+                total_length = ff_dl
+                accumulated = bytearray(frame_data[2:])  # first 6 bytes of data
 
-            sn = 0  # expected sequence number for next CF
+            sn = 1  # expected sequence number for next CF (CF[1] is first)
+
+            # Tell the ECU we're ready to receive the Consecutive Frames --
+            # without this the ECU just times out and never sends them.
+            self._send_flow_control(extflag=extflag)
 
             while len(accumulated) < total_length:
-                cf_frame = self._transport.recv_raw_can(timeout=2.0)
+                cf_frame = self._recv_from_ecu(timeout=2.0)
                 if cf_frame is None:
                     break
                 _, cf_data, _ = cf_frame
+                cf_pci_type = (cf_data[0] & 0xF0) >> 4
+                if cf_pci_type != 0x2:
+                    # Not a Consecutive Frame (stray/duplicate traffic on our
+                    # rx id) -- ignore and keep waiting for the real one.
+                    continue
                 cf_sn = cf_data[0] & 0x0F
 
-                if cf_sn != sn:
+                if cf_sn != (sn & 0x0F):
                     print("ISO-TP consecutive frame sequence error", file=sys.stderr)
                     return None
 
@@ -150,9 +181,34 @@ class IsoTpStack(object):
             else:
                 return bytes(accumulated[:total_length])
 
+            # Loop was broken out of (timeout) rather than completing
+            return None
+
         elif pci_type == 0x3:
-            # -- Response to a request the ECU sent to us; send FC --------------
-            self._send_flow_control()
+            # A Flow Control frame is not a valid response payload here --
+            # we're the one receiving a response, not sending one.  Ignore it.
+            print("ISO-TP: unexpected Flow Control frame while awaiting response", file=sys.stderr)
+            return None
+
+    def _recv_from_ecu(self, timeout):
+        """Wait up to ``timeout`` seconds for a frame addressed to our rx id.
+
+        Any other traffic on the bus (our own echoed tx frames, other ECUs,
+        etc.) is discarded so it can't be mistaken for part of this
+        transaction.
+        """
+        deadline = time.time() + timeout
+        while True:
+            remaining = deadline - time.time()
+            if remaining <= 0:
+                return None
+            frame = self._transport.recv_raw_can(timeout=remaining)
+            if frame is None:
+                return None
+            arbid, frame_data, extflag = frame
+            if arbid == self._rx_id:
+                return frame
+            # not addressed to us -- keep waiting for the rest of the budget
 
     def _parse_flow_control(self, frame_data):
         """Parse and extract flow control parameters.
@@ -184,10 +240,11 @@ class IsoTpStack(object):
             centiseconds = (raw - 0xF1 + 100)
             return int(centiseconds * 10e3)   # cs to us
 
-    def _send_flow_control(self):
-        """Send a Flow Control message back to the ECU."""
+    def _send_flow_control(self, extflag=False):
+        """Send a Flow Control (clear-to-send) frame back to the ECU."""
         fc_frame = struct.pack("BBB",
                                ISO_TP_FC | ISO_TP_FC_CONTINUE,
                                self._fc_bs,                 # block size
                                self._fc_st_min              # STmin
-                              )[:8]  # pad to 8 bytes for CAN frame
+                              )
+        self._transport.send_raw_can(self._tx_id, fc_frame, extflag=extflag)

--- a/cancatlib/j1939.py
+++ b/cancatlib/j1939.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import queue
 import cancatlib
 import struct

--- a/cancatlib/j1939stack.py
+++ b/cancatlib/j1939stack.py
@@ -189,9 +189,9 @@ pgn_pfs = {
 
 class J1939Interface(cancatlib.CanInterface):
     _msg_source_idx = J1939MSGS
-    def __init__(self, port=None, baud=cancatlib.baud, verbose=False, cmdhandlers=None, comment='', load_filename=None, orig_iface=None, process_can_msgs=True, promisc=True):
+    def __init__(self, port=None, baud=cancatlib.baud, verbose=False, cmdhandlers=None, comment='', load_filename=None, orig_iface=None, process_can_msgs=True, promisc=True, transport='serial', socketcan_iface=None):
 
-        cancatlib.CanInterface.__init__(self, port=port, baud=baud, verbose=verbose, cmdhandlers=cmdhandlers, comment=comment, load_filename=load_filename, orig_iface=orig_iface)
+        cancatlib.CanInterface.__init__(self, port=port, baud=baud, verbose=verbose, cmdhandlers=cmdhandlers, comment=comment, load_filename=load_filename, orig_iface=orig_iface, transport=transport, socketcan_iface=socketcan_iface)
         self.register_handler(CMD_CAN_RECV, self._j1939_can_handler)
 
         self._last_recv_idx = -1

--- a/cancatlib/scripts/canmap.py
+++ b/cancatlib/scripts/canmap.py
@@ -284,7 +284,6 @@ def save_results(results, filename=None):
         # TODO: I should probably make the config a class of it's own also, with
         #       .add_ecu(), .add_note(), .export(), .import()
         output_data = {}
-        global _config
         output_data['config'] = results['config']
         output_data['notes'] = dict([(k, literal_unicode(v)) for k, v in results['notes'].items()])
         output_data['ECUs'] = sorted([e for e in results['ECUs'].values()], key=lambda x: x._addr.tx_arbid)
@@ -294,12 +293,10 @@ def save_results(results, filename=None):
 
 
 def save():
-    global _config, _output_filename, _can_session_filename
     if _output_filename:
         save_results(_config, _output_filename)
 
     if _can_session_filename:
-        global c
         c.saveSessionToFile(_can_session_filename)
 
 
@@ -309,7 +306,6 @@ def save_and_exit(retval):
 
 
 def sigint_handler(signum, frame):
-    global _config
     log_and_save(_config, 'scan aborted @ {}'.format(now()))
     save_and_exit(1)
 

--- a/cancatlib/scripts/canmap.py
+++ b/cancatlib/scripts/canmap.py
@@ -1,6 +1,4 @@
 # CAN bus device mapping tool
-from __future__ import print_function
-
 import sys
 import argparse
 import re

--- a/cancatlib/test/test_types.py
+++ b/cancatlib/test/test_types.py
@@ -1,0 +1,97 @@
+import unittest
+
+from cancatlib.utils.types import _dec_range, _hex_range, SparseRange, SparseHexRange, ECUAddress
+
+
+class DecRangeTest(unittest.TestCase):
+    def test_single_value(self):
+        self.assertEqual(5, _dec_range('5'))
+
+    def test_range(self):
+        result = _dec_range('3-7')
+        self.assertEqual(range(3, 8), result)
+        self.assertEqual([3, 4, 5, 6, 7], list(result))
+
+    def test_range_with_increment(self):
+        result = _dec_range('0-10', increment=2)
+        self.assertEqual([0, 2, 4, 6, 8, 10], list(result))
+
+
+class HexRangeTest(unittest.TestCase):
+    def test_single_value(self):
+        self.assertEqual(0xA, _hex_range('a'))
+
+    def test_range(self):
+        result = _hex_range('a-f')
+        self.assertEqual(range(0xA, 0x10), result)
+        self.assertEqual([0xA, 0xB, 0xC, 0xD, 0xE, 0xF], list(result))
+
+    def test_range_with_increment(self):
+        result = _hex_range('0-10', increment=4)
+        self.assertEqual([0, 4, 8, 0xC, 0x10], list(result))
+
+
+class SparseRangeTest(unittest.TestCase):
+    def test_single_values(self):
+        sr = SparseRange('1,5,10')
+        self.assertEqual([1, 5, 10], list(sr))
+
+    def test_mixed_values_and_ranges(self):
+        sr = SparseRange('1,3-5,10')
+        self.assertEqual([1, 3, 4, 5, 10], list(sr))
+
+    def test_contains_single_value(self):
+        sr = SparseRange('1,3-5,10')
+        self.assertIn(1, sr)
+        self.assertNotIn(2, sr)
+
+    def test_contains_within_range(self):
+        sr = SparseRange('1,3-5,10')
+        self.assertIn(3, sr)
+        self.assertIn(4, sr)
+        self.assertIn(5, sr)
+        self.assertNotIn(6, sr)
+        self.assertNotIn(9, sr)
+
+    def test_repr_and_str(self):
+        sr = SparseRange('1,3-5')
+        self.assertEqual('SparseRange', sr._get_classname())
+        self.assertTrue(repr(sr).startswith('SparseRange('))
+        self.assertEqual(str(tuple.__str__(sr)), str(sr))
+
+
+class SparseHexRangeTest(unittest.TestCase):
+    def test_mixed_values_and_ranges(self):
+        shr = SparseHexRange('a,3-5,10')
+        self.assertEqual([0xA, 3, 4, 5, 0x10], list(shr))
+
+    def test_contains(self):
+        shr = SparseHexRange('a,3-5,10')
+        self.assertIn(0xA, shr)
+        self.assertIn(4, shr)
+        self.assertNotIn(6, shr)
+
+    def test_is_a_sparse_range(self):
+        shr = SparseHexRange('a')
+        self.assertIsInstance(shr, SparseRange)
+        self.assertEqual('SparseHexRange', shr._get_classname())
+
+
+class ECUAddressTest(unittest.TestCase):
+    def test_equality(self):
+        self.assertEqual(ECUAddress(0x711, 0x719, 0), ECUAddress(0x711, 0x719, 0))
+        self.assertNotEqual(ECUAddress(0x711, 0x719, 0), ECUAddress(0x711, 0x71A, 0))
+
+    def test_iter_and_len(self):
+        addr = ECUAddress(0x711, 0x719, 0)
+        self.assertEqual((0x711, 0x719, 0), tuple(addr))
+        self.assertEqual(3, len(addr))
+
+    def test_hashable(self):
+        # ECUAddress objects should be usable as dict keys / set members
+        s = {ECUAddress(0x711, 0x719, 0), ECUAddress(0x711, 0x719, 0)}
+        self.assertEqual(1, len(s))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/cancatlib/test/test_uds.py
+++ b/cancatlib/test/test_uds.py
@@ -2,7 +2,7 @@ import unittest
 
 from cancatlib.utils.types import ECUAddress
 from cancatlib.uds.ecu import ECU
-from cancatlib.uds.utils import ecu_did_scan, ecu_session_scan
+from cancatlib.uds.utils import ecu_did_scan, ecu_session_scan, did_str, gen_uds_resp_range
 from cancatlib.uds.test import CanInterface, FakeUDS
 
 
@@ -64,3 +64,37 @@ class UDStest(unittest.TestCase):
 
             for did in test['dids'].keys():
                 self.assertEqual(test['dids'][did], ecu._sessions[1]['dids'][did]['resp'])
+
+    def test_did_str_known_did(self):
+        # A DID present in ISO_14229_DIDS should be resolved by name, not by
+        # the generic manufacturer/supplier-specific range fallback.
+        self.assertEqual('0xf190 (VINDataIdentifier)', did_str(0xF190))
+
+    def test_did_str_generic_vehicle_manufacturer_range(self):
+        # DIDs 0xf1a0-0xf1ef are reserved for vehicle-manufacturer-specific
+        # use and aren't individually named in ISO_14229_DIDS.
+        self.assertEqual(
+            '0xf1a5 (identificationOptionVehicleManufacturerSpecific)', did_str(0xF1A5))
+
+    def test_did_str_generic_system_supplier_range(self):
+        # DIDs 0xf1f0-0xf1ff are reserved for system-supplier-specific use.
+        self.assertEqual(
+            '0xf1f5 (identificationOptionSystemSupplierSpecific)', did_str(0xF1F5))
+
+    def test_did_str_unknown_did(self):
+        # A DID outside both ISO_14229_DIDS and the generic ranges just
+        # renders as hex, with no name.
+        self.assertEqual('0x1234', did_str(0x1234))
+
+    def test_gen_uds_resp_range_11bit(self):
+        # 11-bit (standard) addressing always uses the fixed 0x700-0x7ff
+        # OBD2/UDS response range.
+        resp_range = gen_uds_resp_range(0x711)
+        self.assertEqual(range(0x700, 0x800), resp_range)
+
+    def test_gen_uds_resp_range_29bit(self):
+        # 29-bit (extended) addressing computes a range based on the
+        # request arbid instead of using a fixed range.
+        resp_range = gen_uds_resp_range(0x18DA01F1)
+        self.assertIsInstance(resp_range, range)
+        self.assertEqual(0x100, len(resp_range))

--- a/cancatlib/transport.py
+++ b/cancatlib/transport.py
@@ -9,6 +9,11 @@ import struct
 import sys
 import threading
 
+try:
+    import can  # python-can; only required for the socketcan transport
+except ImportError:
+    can = None
+
 
 class Transport(object):
     """Abstract base class for CAN communication."""
@@ -106,11 +111,21 @@ class SocketcanTransport(Transport):
         self._lock_cond = threading.Condition()
         self._rx_thread = None
         self._running = False
+        self._subscribers = []        # list of {"queue": [...], "cond": Condition()}
 
     def open(self):
         """Start the SocketCAN bus and background rx thread."""
-        import can  # python-can
-        self._bus = can.Bus(channel=self.channel, bustype="socketcan", bitrate=self._bitrate)
+        if can is None:
+            raise ImportError(
+                "python-can is required for socketcan transport. "
+                "Install it with: pip install python-can"
+            )
+        # receive_own_messages so our own transmitted frames get looped back
+        # through the same rx path -- this is what makes sent CAN/UDS
+        # traffic show up in printCanMsgs(), mirroring how the custom
+        # firmware sees its own transmissions reflected on the physical bus.
+        self._bus = can.Bus(channel=self.channel, bustype="socketcan",
+                             bitrate=self._bitrate, receive_own_messages=True)
         self._running = True
         self._rx_thread = threading.Thread(target=self._rx_loop, daemon=True)
         self._rx_thread.start()
@@ -141,12 +156,58 @@ class SocketcanTransport(Transport):
         self._bus.send(can_msg)
 
     def recv_raw_can(self, timeout: float = 1.0):
-        """Wait for next (arbid, data_bytes, extflag) from rx queue."""
+        """Wait for next (arbid, data_bytes, extflag) from the default rx queue.
+
+        This is a single shared queue -- if more than one consumer needs to
+        read frames concurrently (e.g. the background message logger *and*
+        an ISO-TP transaction), use :meth:`subscribe` instead so each
+        consumer gets its own private copy of every frame rather than the
+        two of them stealing frames from each other.
+        """
         with self._lock_cond:
             if not self._recv_queue:
                 ready = self._lock_cond.wait(timeout=timeout)
             if self._recv_queue:
                 return self._recv_queue.pop(0)
+            return None
+
+    # -- fan-out subscriptions ------------------------------------------
+    #
+    # A single can.Bus is shared by everything that talks to this channel:
+    # the background thread that records frames for printCanMsgs(), and any
+    # in-flight ISO-TP transaction that needs to see FC/CF frames.  If they
+    # all pulled from one queue via recv_raw_can(), whichever one happened
+    # to be waiting would "steal" each frame from the others.  subscribe()
+    # instead hands out a view that receives its own private copy of every
+    # incoming frame.
+
+    def subscribe(self):
+        """Return a transport-like view with its own private fan-out queue.
+
+        The returned object exposes ``send_raw_can``/``recv_raw_can`` (just
+        like this transport) so it can be handed to anything that expects a
+        Transport, e.g. :class:`cancatlib.isotp_stack.IsoTpStack`. Call
+        ``.close()`` on it when done to stop receiving frames.
+        """
+        handle = {"queue": [], "cond": threading.Condition()}
+        with self._lock_cond:
+            self._subscribers.append(handle)
+        return _Subscription(self, handle)
+
+    def unsubscribe(self, handle):
+        with self._lock_cond:
+            if handle in self._subscribers:
+                self._subscribers.remove(handle)
+
+    def recv_subscribed(self, handle, timeout: float = 1.0):
+        """Wait for the next frame fanned out to ``handle`` (see subscribe())."""
+        cond = handle["cond"]
+        queue = handle["queue"]
+        with cond:
+            if not queue:
+                cond.wait(timeout=timeout)
+            if queue:
+                return queue.pop(0)
             return None
 
     # -- background receiver ------------------------------------------
@@ -162,7 +223,35 @@ class SocketcanTransport(Transport):
                     with self._lock_cond:
                         self._recv_queue.append(entry)
                         self._lock_cond.notify()
+                        subscribers = list(self._subscribers)
+                    for handle in subscribers:
+                        with handle["cond"]:
+                            handle["queue"].append(entry)
+                            handle["cond"].notify()
             except Exception as e:
                 if self._running:
                     import sys
                     print(f"SocketCAN rx error: {e}", file=sys.stderr, flush=True)
+
+
+class _Subscription:
+    """A private, per-consumer view onto a :class:`SocketcanTransport`.
+
+    Satisfies the same ``send_raw_can``/``recv_raw_can`` interface as a
+    Transport, but ``recv_raw_can`` reads from a dedicated fan-out queue
+    (see :meth:`SocketcanTransport.subscribe`) instead of the shared default
+    queue, so it never competes with other consumers for frames.
+    """
+
+    def __init__(self, transport: "SocketcanTransport", handle):
+        self._transport = transport
+        self._handle = handle
+
+    def send_raw_can(self, arbid: int, data: bytes, extflag: bool = False):
+        return self._transport.send_raw_can(arbid, data, extflag=extflag)
+
+    def recv_raw_can(self, timeout: float = 1.0):
+        return self._transport.recv_subscribed(self._handle, timeout=timeout)
+
+    def close(self):
+        self._transport.unsubscribe(self._handle)

--- a/cancatlib/transport.py
+++ b/cancatlib/transport.py
@@ -1,0 +1,169 @@
+"""CAN transport abstraction layer for CanCat.
+
+Provides a common interface for serial and socketcan backends so that
+higher-level CAN methods (CanInterface) can work identically regardless of
+the underlying physical medium.  No existing serial behaviour is changed.
+"""
+from __future__ import print_function
+import select
+import struct
+import sys
+import threading
+
+
+class Transport(object):
+    """Abstract base class for CAN communication."""
+
+    def open(self) -> None:
+        raise NotImplementedError("Transport.open() must be overridden")
+
+    def close(self) -> None:
+        raise NotImplementedError("Transport.close() must be overridden")
+
+    # -- low-level frame I/O ------------------------------------------
+
+    def send_raw_can(self, arbid: int, data: bytes, extflag: bool = False):
+        """Send a single raw CAN frame (max 8-byte payload)."""
+        raise NotImplementedError
+
+    def recv_raw_can(self, timeout: float = 1.0):
+        """Block up to ``timeout`` seconds for the next CAN frame.
+
+        Returns ``(arbid, data_bytes, extflag)`` or ``None`` on timeout.
+        """
+        raise NotImplementedError
+
+    # -- convenience --------------------------------------------------
+
+    def xmit_raw_can(self, arbid: int, data: bytes, extflag: bool = False):
+        """Send-and-return variant."""
+        return self.send_raw_can(arbid, data, extflag=extflag)
+
+# =====================================================================
+#  SerialTransport -- thin wrapper around existing CanInterface serial code
+# =====================================================================
+
+class SerialTransport(Transport):
+    """Transport over CanCat custom serial binary protocol.
+
+    The actual framing logic (_send, _rxtx receiver thread) is kept inside
+    :class:`CanInterface` to avoid any regression risk.  This class just
+    provides a consistent interface and delegates CAN reads/writes to the
+    parent CanInterface instance via its public serial methods.
+    """
+
+    def __init__(self, port: str, baud: int = 4000000):
+        self.port = port
+        self._baud = baud
+        self._io = None               # serial.Serial instance -- set by _reconnect()
+        self._can_recv_queue = []     # list of (arbid, data_bytes) tuples from rx thread
+        self._lock_cond = threading.Condition()
+
+    def open(self):
+        """Opened implicitly by CanInterface._reconnect()."""
+        pass
+
+    def close(self):
+        if hasattr(self, "_io") and self._io:
+            try:
+                self._io.close()
+            except Exception:
+                pass
+            finally:
+                self._io = None
+
+    # -- frame I/O ----------------------------------------------------
+
+    def send_raw_can(self, arbid: int, data: bytes, extflag: bool = False):
+        """Enqueue a raw CAN frame for the background serial sender."""
+        raise NotImplementedError("Wired to CanInterface._send() in later phase")
+
+    def recv_raw_can(self, timeout: float = 1.0):
+        """Wait for next CAN frame from the rx thread queue."""
+        with self._lock_cond:
+            if not self._can_recv_queue:
+                ready = self._lock_cond.wait(timeout=timeout)
+            if self._can_recv_queue:
+                return self._can_recv_queue.pop(0)
+            return None
+
+# =====================================================================
+#  SocketCANTransport -- direct Linux SocketCAN via python-can / raw sockets
+# =====================================================================
+
+class SocketcanTransport(Transport):
+    """Direct Linux SocketCAN transport.
+
+    Uses ``python-can`` as the backend — either the native linux_socketcan
+    bus or a raw BSD socket.  ISO-TP flow control is handled in the Python
+    layer (via :class:`IsoTpStack`) since SocketCAN has no firmware to do it.
+    """
+
+    def __init__(self, channel: str = "can0", bitrate: int = 500000):
+        self.channel = channel
+        self._bitrate = bitrate
+        self._bus = None              # can.Bus instance
+        self._recv_queue = []         # list of (arbid, data_bytes, extflag)
+        self._lock_cond = threading.Condition()
+        self._rx_thread = None
+        self._running = False
+
+    def open(self):
+        """Start the SocketCAN bus and background rx thread."""
+        import can  # python-can
+        self._bus = can.Bus(channel=self.channel, bustype="socketcan", bitrate=self._bitrate)
+        self._running = True
+        self._rx_thread = threading.Thread(target=self._rx_loop, daemon=True)
+        self._rx_thread.start()
+
+    def close(self):
+        """Stop rx thread and shut down bus."""
+        self._running = False
+        if self._bus is not None:
+            try:
+                self._bus.shutdown()
+            except Exception:
+                pass
+            finally:
+                self._bus = None
+
+    # -- frame I/O ----------------------------------------------------
+
+    def send_raw_can(self, arbid: int, data: bytes, extflag: bool = False):
+        """Send a single CAN frame on the SocketCAN bus."""
+        if self._bus is None:
+            raise RuntimeError("Bus not opened (did you forget transport.open()?)")
+        padded = bytes(list(data) + [0] * (8 - len(data)))[:8]
+        can_msg = can.Message(
+            arbitration_id=arbid,
+            data=padded,
+            is_extended_id=extflag,
+        )
+        self._bus.send(can_msg)
+
+    def recv_raw_can(self, timeout: float = 1.0):
+        """Wait for next (arbid, data_bytes, extflag) from rx queue."""
+        with self._lock_cond:
+            if not self._recv_queue:
+                ready = self._lock_cond.wait(timeout=timeout)
+            if self._recv_queue:
+                return self._recv_queue.pop(0)
+            return None
+
+    # -- background receiver ------------------------------------------
+
+    def _rx_loop(self):
+        """Background thread: read from SocketCAN bus and enqueue frames."""
+        while self._running:
+            try:
+                frame = self._bus.recv(timeout=0.5)  # non-blocking-ish poll
+                if frame is not None:
+                    raw_data = bytes(frame.data[:frame.dlc])
+                    entry = (frame.arbitration_id, raw_data, frame.is_extended_id)
+                    with self._lock_cond:
+                        self._recv_queue.append(entry)
+                        self._lock_cond.notify()
+            except Exception as e:
+                if self._running:
+                    import sys
+                    print(f"SocketCAN rx error: {e}", file=sys.stderr, flush=True)

--- a/cancatlib/transport.py
+++ b/cancatlib/transport.py
@@ -4,7 +4,6 @@ Provides a common interface for serial and socketcan backends so that
 higher-level CAN methods (CanInterface) can work identically regardless of
 the underlying physical medium.  No existing serial behaviour is changed.
 """
-from __future__ import print_function
 import select
 import struct
 import sys

--- a/cancatlib/uds/__init__.py
+++ b/cancatlib/uds/__init__.py
@@ -223,8 +223,12 @@ class UDS(object):
                 # Don't throw an exception for
                 # ResponseCorrectlyReceivedResponsePending
                 if errcode == 0x78:
-                    # Try again but increment the start index
-                    msg, idx = self.c._isotp_get_msg(self.rx_arbid, start_index=idx+1, service=service, timeout=self.timeout)
+                    # Try again but increment the start index. idx is None
+                    # under socketcan (there's no mailbox position to resume
+                    # from -- _isotp_get_msg just waits for the next ISO-TP
+                    # message on rx_arbid instead), so guard against it.
+                    next_index = (idx + 1) if idx is not None else None
+                    msg, idx = self.c._isotp_get_msg(self.rx_arbid, start_index=next_index, service=service, timeout=self.timeout, tx_arbid=self.tx_arbid)
                 else:
                     raise NegativeResponseException(errcode, svc, msg)
 

--- a/cancatlib/uds/__init__.py
+++ b/cancatlib/uds/__init__.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from builtins import input
-
 import sys
 import time
 import struct

--- a/cancatlib/uds/utils.py
+++ b/cancatlib/uds/utils.py
@@ -8,7 +8,7 @@ from contextlib import contextmanager
 from cancatlib import uds, ARBID_29BIT
 from cancatlib.uds import UDS
 from cancatlib.utils import log
-from cancatlib.utils.types import ECUAddress, _range_func
+from cancatlib.utils.types import ECUAddress
 
 
 def get_uds_29bit_srcid(arbid):
@@ -31,14 +31,14 @@ def gen_uds_resp_range(arbid):
         dest_id = get_uds_29bit_srcid(arbid)
         base_id = uds.ARBID_CONSTS[ARBID_29BIT]['prefix'] & (dest_id << uds.ARBID_CONSTS[ARBID_29BIT]['destid_shift'])
 
-        return _range_func(base_id, base_id + 0x100)
+        return range(base_id, base_id + 0x100)
     else:
         # Assume this is an 11-bit request
         #
         # Normally if a request is sent to 0x710, the response should have an
         # arbitration ID of 0x718, but not all ECUs do things in a "normal" way,
         # so generate a range of possible response IDs.
-        return _range_func(0x700, 0x800)
+        return range(0x700, 0x800)
 
 
 def gen_arbids(idx, ext=0):
@@ -142,9 +142,9 @@ def did_str(did):
 
     # Handle some generic DID ranges
     if name_str is None:
-        if did in _range_func(0xf1a0, 0xf1ef+1):
+        if did in range(0xf1a0, 0xf1ef+1):
             name_str = 'identificationOptionVehicleManufacturerSpecific'
-        elif did in _range_func(0xf1f0, 0xf1ff+1):
+        elif did in range(0xf1f0, 0xf1ff+1):
             name_str = 'identificationOptionSystemSupplierSpecific'
 
     if name_str:

--- a/cancatlib/utils/log.py
+++ b/cancatlib/utils/log.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import sys
 
 

--- a/cancatlib/utils/log.py
+++ b/cancatlib/utils/log.py
@@ -132,8 +132,6 @@ def stop():
 
 
 def log(level, *args):
-    global _log_level, _log_file, _use_color
-
     if len(args) == 0:
         msg = ''
     elif len(args) == 1:

--- a/cancatlib/utils/types.py
+++ b/cancatlib/utils/types.py
@@ -1,14 +1,5 @@
 # Various types used by CanCat utility functions.
-from past.builtins import xrange
-
 import re
-
-# Test if this is python2 or python3
-try:
-    _ = xrange(1, 2)
-    _range_func = xrange
-except NameError:
-    _range_func = range
 
 
 def _dec_range(val, increment=1):
@@ -16,7 +7,7 @@ def _dec_range(val, increment=1):
     if len(parts) == 1:
         return int(parts[0])
     else:
-        return _range_func(int(parts[0]), int(parts[1]) + 1, increment)
+        return range(int(parts[0]), int(parts[1]) + 1, increment)
 
 
 def _hex_range(val, increment=1):
@@ -24,7 +15,7 @@ def _hex_range(val, increment=1):
     if len(parts) == 1:
         return int(parts[0], 16)
     else:
-        return _range_func(int(parts[0], 16), int(parts[1], 16) + 1, increment)
+        return range(int(parts[0], 16), int(parts[1], 16) + 1, increment)
 
 
 class SparseRange(tuple):

--- a/docs/PLAN_SOCKETCAN.md
+++ b/docs/PLAN_SOCKETCAN.md
@@ -1,0 +1,645 @@
+# PLAN: Add SocketCAN Transport Support to CanCat
+
+## Background
+
+CanCat currently communicates with a dedicated USB-connected firmware device (the CanCat transceiver) over serial. The firmware handles all CAN bus physical layer operations and ISO-TP flow control internally, exposing a simple custom binary protocol (`@<size><cmd><payload>`) over the serial port to the Python client.
+
+This plan describes adding **socketcan** as an alternative transport mode, allowing CanCat to operate directly against Linux socketCAN interfaces (e.g., `vcan`, `can0`, or hardware adapters like PEAK/Sonoelectrics supported by kernel drivers). This enables using CanCat tools without any dedicated firmware device, at the cost of moving ISO-TP flow control from firmware into Python.
+
+**Key principle:** Full backward compatibility. No existing behavior changes for users operating in serial mode. All `CanInterface` subclasses (`FordInterface`, `GMInterface`, `J1939`, etc.) continue unchanged.
+
+---
+
+## Phase 1: Transport Abstraction Layer (`cancatlib/transport.py`)
+
+Introduce a transport layer that isolates the physical communication mechanism from CanCat's higher-level CAN logic. This lets us swap serial ↔ socketcan with minimal changes elsewhere.
+
+### Step 1.1 — Define abstract base class `Transport`
+
+Create `cancatlib/transport.py` and define:
+
+```python
+from abc import ABC, abstractmethod
+
+class Transport(ABC):
+    """Abstract transport layer for CAN communication."""
+
+    @abstractmethod
+    def open(self) -> None: ...        # Open the underlying connection (serial port / socketcan bus).
+    @abstractmethod
+    def close(self) -> None: ...       # Close and release resources.
+
+    @abstractmethod
+    def send_raw_can(self, arbid: int, data: bytes, extflag: bool = False) -> int:
+        """Send a single CAN frame (no flow-control). Returns byte count or status."""
+
+    @abstractmethod
+    def recv_raw_can(self, timeout: float) -> tuple[int, bytes, bool]:
+        """Block up to `timeout` seconds for the next CAN frame.
+        Returns (arbid, data_bytes, extflag) or None on timeout."""
+
+    # Convenience alias preferred by CanInterface:
+    @abstractmethod
+    def xmit_raw_can(self, arbid: int, data: bytes, extflag: bool = False) -> int:
+        """Send-and-return variant (may include acknowledgment for serial path)."""
+
+```
+
+**Design rationale:**
+- `send_raw_can` / `recv_raw_can` are the symmetric low-level operations.
+- `xmit_raw_can` is preserved as a drop-in alias because the existing CanInterface code already calls it via `_io.write()` + response pattern in some paths.
+- The layer operates on **raw CAN frames** (single 11-byte max). ISO-TP segmentation and flow control sit *above* this layer.
+
+### Step 1.2 — Implement `SerialTransport`
+
+Extract the current serial-path logic from `CanInterface._reconnect()`, `_rxtx()`, and `_send()` into a dedicated transport class:
+
+```python
+import serial
+import threading
+
+class SerialTransport(Transport):
+    """Transport over CanCat's custom serial binary protocol."""
+
+    FRAMING_PREFIX = None   # '@' byte for command framing
+    CMD_CAN_XMIT     = 0x30  # (or whatever hex values the firmware uses)
+    CMD_PING         = 0x...
+    CMD_CHANGE_BAUD  = 0x...
+    # ... constants currently in __init__.py ...
+
+    def __init__(self, port: str, baud: int = 4_000_000):
+        self.port = port
+        self.baud = baud
+        self._io: serial.Serial | None = None
+        self._lock = threading.Lock()
+        # ...
+
+    def open(self) -> None:
+        """Open the serial port, send ping handshake, configure CAN baud."""
+        ...
+
+    def close(self) -> None:
+        if self._io and self._io.is_open:
+            self._io.close()
+
+    # --- internal helpers (extracted from CanInterface) ---
+
+    def _send(self, cmd: int, payload: bytes = b'') -> bytes:
+        """Frame a command as @<size><cmd><payload> over serial."""
+        ...
+
+    def recv_response(self, timeout: float = 0.5) -> bytes:
+        """Read response from firmware, handle framing and checksums."""
+        ...
+
+    # --- Transport ABC methods ---
+
+    def send_raw_can(self, arbid: int, data: bytes, extflag: bool = False) -> int:
+        """Encode CAN frame in serial protocol payload, send to device."""
+        self._send(CMD_CAN_XMIT, struct.pack(...) + bytes([arbid ...]) + data)
+        return 0
+
+    def xmit_raw_can(self, arbid: int, data: bytes, extflag: bool = False) -> int:
+        """Send frame and read device acknowledgment."""
+        self.send_raw_can(arbid, data, extflag)
+        response = self.recv_response()
+        return ...  # status byte or byte count
+
+    def recv_raw_can(self, timeout: float) -> tuple[int, bytes, bool]:
+        """Read from serial receive buffer (populated by _rxtx receiver thread)."""
+        with self._lock:
+            # Use select.poll on the serial fd for timed reads.
+            ...
+
+```
+
+**Key extraction decisions:**
+- `_reconnect()` → logic folds into `SerialTransport.open()`.
+- `_send()` → becomes `SerialTransport._send()` (private helper, not part of ABC).
+- The serial receiver thread (`_rxtx()` receiver half) either lives in `SerialTransport` or stays at the `CanInterface` level depending on whether subclasses expect it. **Recommendation:** move the receive loop into `SerialTransport.open()` as a daemon thread that pushes frames into an internal queue; `recv_raw_can()` pulls from that queue with timeout support via `select()`.
+
+**Backward-compatibility check:** After extraction, instantiating `CanInterface` in serial mode must produce byte-for-byte identical wire behavior. The only change is *where* the code lives.
+
+### Step 1.3 — Implement `SocketcanTransport`
+
+A simple transport backed by **python-can**'s socketcan backend:
+
+```python
+import can   # python-can library
+
+class SocketcanTransport(Transport):
+    """Direct Linux socketCAN transport via python-can."""
+
+    def __init__(self, channel: str = 'can0'):
+        self.channel = channel
+        self._bus: can.BusABC | None = None
+
+    def open(self) -> None:
+        self._bus = can.Bus(bustype='socketcan', channel=self.channel)
+
+    def close(self) -> None:
+        if self._bus:
+            self._bus.shutdown()
+            self._bus = None
+
+    def send_raw_can(self, arbid: int, data: bytes, extflag: bool = False) -> int:
+        frame = can.Message(arbitration_id=arbid,
+                            data=list(data),
+                            is_extended_id=extflag)
+        self._bus.send(frame)
+        return len(data)
+
+    def xmit_raw_can(self, arbid: int, data: bytes, extflag: bool = False) -> int:
+        # Same as send_raw_can for socketcan — no separate ack handshake.
+        return self.send_raw_can(arbid, data, extflag)
+
+    def recv_raw_can(self, timeout: float) -> tuple[int, bytes, bool] | None:
+        frame = self._bus.recv(timeout=timeout)  # python-can blocks internally
+        if frame is None:
+            return None
+        return (frame.arbitration_id, bytes(frame.data[:frame.dlc]), frame.is_extended_id)
+
+```
+
+**No receiver thread** needed here — `can.Bus.recv()` already supports blocking with timeout natively (libsocketcan's blocking read). This simplifies the code enormously compared to the serial path.
+
+### Step 1.4 — Smoke-test both transports independently
+
+Before touching CanInterface, verify each transport in isolation:
+
+- **SerialTransport**: Ensure it connects to a plugged-in CanCat device and successfully pings/reads frames. (Integration test — requires hardware.)
+- **SocketcanTransport**: Create `vcan0`, write/read CAN frames via `ip link` + python-can on a second thread/process, confirm `_recv_raw_can()` returns them correctly.
+
+---
+
+## Phase 2: ISO-TP Flow Control in Python (`cancatlib/isotp_stack.py`)
+
+Currently the CanCat firmware handles ISO-TP (ISO 15765-2) flow control for multi-frame messages. In socketcan mode, there is no firmware — we need to do this entirely in Python using the `isotp.Protocol` class from the **python-isotp** library (already installed in .venv).
+
+### Step 2.1 — Create `cancatlib/isotp_stack.py`
+
+Design a thin wrapper that presents clean synchronous functions for CAN-ISOTP send/recv over any transport:
+
+```python
+"""ISO-TP stack helpers wrapping isotp.Protocol for socketcan mode."""
+
+import isotp
+from .transport import Transport
+```
+
+**Why a wrapper instead of calling `isotp.Protocol` directly:** The `isotp.Protocol` class expects `send()` callbacks that accept raw CAN frames, but our transports operate through the shared `Transport.send_raw_can()` / `recv_raw_can()` interface. Our functions set up the correct Protocol instances and tie them together with TX/RX IDs.
+
+### Step 2.2 — Implement core function: `send_isotp(transport, tx_id, rx_id, data)`
+
+```python
+import struct
+import time
+from enum import IntEnum
+
+class IsoTPError(Exception): ...
+
+def send_isotp(transport: Transport, tx_id: int, rx_id: int,
+               data: bytes, timeout: float = 5.0) -> iso_tp.CanIsoMsgException | None:
+    """Send an ISO-TP message (handles single-frame and multi-frame segmentation)."""
+```
+
+**Implementation approach:**
+
+1. If `len(data) <= 7`, send as a **single frame** (SF): `transport.send_raw_can(rx_id, bytes([0x00 | len(data)] + data))`. Done.
+2. Otherwise:
+   - Create an `isotp.Protocol` sender using the transport for TX and a dummy receiver:
+
+     ```python
+     protocol = isotp.Protocol(
+         tx_path=functools.partial(transport.send_raw_can, extflag=False),
+         rx_path=_read_response_callback,  # reads from transport.recv_raw_can()
+     )
+     ```
+
+   - The Protocol handles frame numbering, sends FF (first frame) with total length, receives FC (flow control) back, then streams CF (consecutive frames) respecting **BS** (block size) and **STmin** (separation time minimum).
+   - After transmitting all data, verify the sender status is complete.
+
+3. On timeout or error, raise `IsoTPError`.
+
+### Step 2.3 — Implement: `recv_isotp(transport, tx_id, rx_id)`
+
+```python
+def recv_isotp(transport: Transport, tx_id: int, rx_id: int,
+               timeout: float = 5.0) -> bytes:
+    """Receive an ISO-TP message (reads SF/FF+CF frames, handles flow control)."""
+```
+
+**Implementation approach:**
+
+1. Build `isotp.Protocol` with the transport — this time we *listen* on `tx_id` for incoming messages and send FC responses from `rx_id`.
+2. The Protocol class automatically:
+   - Reads SF/FF frames arriving from TX ID (our RX path).
+   - On FF, sends an **FC (Flow Control)** frame to the TX side with configurable STmin/BS.
+   - Assembles consecutive CF frames into a complete message.
+3. Call `protocol.send(b'')` or similar to start the receive handshake if needed (some python-isotp APIs require triggering). Or use `isotp.recv()` pattern where we just pass `tx_path` and `rx_path`.
+4. Return assembled bytes when complete, or raise on timeout.
+
+**Important nuance:** For socketcan mode we must send FC (Flow Control) frames **back-to-back** as responses to FF (First Frame). The `isotp.Protocol` class handles this internally via its `tx_path` callback — our wrapper just needs to wire it up so TX writes go to our transport.
+
+### Step 2.4 — Implement: `sendrecv_isotp(transport, tx_id, rx_id, request_data)`
+
+```python
+def sendrecv_isotp(transport: Transport, tx_id: int, rx_id: int,
+                   request_data: bytes, timeout: float = 5.0) -> bytes:
+    """Send an ISO-TP request and return the response (request-response pattern)."""
+```
+
+1. Call `send_isotp()` with `rx_id` as destination for the request.
+2. Immediately call `recv_isotp()` listening on `tx_id` for the response.
+3. Return the received response bytes.
+
+### Step 2.5 — Implement: `sniff_isotp(transport, tx_id, rx_id)` (optional / advanced)
+
+For modes where we want to passively capture ISO-TP traffic:
+
+```python
+def sniff_isotp(transport: Transport, rx_id: int, timeout: float = 1.0) -> bytes | None:
+    """Passively reassemble ISO-TP messages without sending flow control.
+    Use case: listening where the device already handles FC."""
+```
+
+May use `cancatlib.iso_tp`'s existing static decode logic for single-frame, or a simplified Protocol in passive mode.
+
+### Step 2.6 — Edge cases to handle explicitly
+
+- **STmin = 0**: Some ECUs specify zero millisecond separation time between CF frames. Must support burst sends (no `time.sleep()`).
+- **BS = 0**: Block size of zero means "send all remaining frames without flow control." Protocol must detect this and pump the entire message after receiving FF+FC(BC=0)+STmin=0.
+- **Partial messages / timeouts**: If FC is not received within timeout, discard partial buffer and raise an error. Don't leave stale state in the transport or protocol object.
+- **Multi-session isolation**: Each call to `send_isotp()`/`recv_isotp()` must use a *fresh* Protocol instance so async operations don't interfere (socketcan mode is single-threaded blocking, but callers may run in threads).
+
+---
+
+## Phase 3: CanInterface Integration
+
+Wire the transport layer and ISO-TP stack into the existing `CanInterface` class at `cancatlib/__init__.py`.
+
+### Step 3.1 — Modify `CanInterface.__init__()` signature
+
+```python
+def __init__(self, port=None, baud=baud, verbose=False, cmdhandlers=None,
+             comment='', load_filename=None, orig_iface=None, max_msgs=None,
+             transport='serial', socketcan_iface=None):
+    '''CAN Analysis Workspace.
+
+    Args:
+        ...  (existing args unchanged)
+        transport: 'serial' or 'socketcan'. Default 'serial' for backward compat.
+        socketcan_iface: Interface name for socketcan mode (e.g., 'vcan0', 'can0').
+    '''
+```
+
+Backward compatibility guarantee: All existing positional and keyword arguments remain in the same order and keep their defaults. Only new **keyword-only** additions appended at the end.
+
+### Step 3.2 — Instantiate transport based on mode
+
+Inside `__init__`, after logging setup but before any CAN bus operations:
+
+```python
+from .transport import SerialTransport, SocketcanTransport
+
+if self.transport_mode == 'serial':
+    if port is None:
+        raise ValueError('port required for serial transport')
+    self._transport = SerialTransport(port=port, baud=self.can_baud)
+elif self.transport_mode == 'socketcan':
+    iface = socketcan_iface if socketcan_iface else 'vcan0'
+    self._transport = SocketcanTransport(channel=iface)
+else:
+    raise ValueError(f"Unsupported transport mode: {self.transport_mode!r}")
+
+# Open the connection (handshake for serial, bus init for socketcan).
+self._transport.open()
+```
+
+### Step 3.3 — Route `CANxmit()` through transport layer
+
+**Existing code path (serial):**  
+`CANxmit(msg)` already handles sending raw CAN frames via the `_io` serial writer and reading back results.
+
+**New polymporphic design:**
+
+```python
+def CANxmit(self, message):
+    """Send a single CAN frame. `message = [arbid, data_bytes]."""
+    (arbid, data) = message[0], bytes(message[1])  # normalize input
+    if self.transport_mode == 'serial':
+        return self._transport.xmit_raw_can(arbid, data)
+    else:
+        return self._transport.send_raw_can(arbid, data)
+```
+
+Keep the existing `CANxmit` signature and message format. Internal dispatch to `self._transport`.
+
+### Step 3.4 — Rewrite `ISOTPxmit()` / `ISOTPrecv()` / `ISOTPxmit_recv()` as polymorphic methods
+
+These three methods currently invoke firmware-level ISO-TP commands (the device handles segmentation, flow control, and reassembly). We need them to work with both transports:
+
+```python
+from . import isotp_stack
+
+def ISOTPxmit(self, data, IDtx=None, IDrx=None):
+    """Send multi-frame ISO-TP message."""
+    if self.transport_mode == 'serial':
+        # Existing code — sends via firmware command.
+        ...   # unchanged
+    else:
+        return isotp_stack.send_isotp(
+            self._transport, tx_id=IDtx, rx_id=IDrx, data=data
+        )
+
+def ISOTPrecv(self, addr=None):
+    """Receive ISO-TP message with flow control."""
+    if self.transport_mode == 'serial':
+        # Existing code — queries firmware.
+        ...   # unchanged
+    else:
+        return isotp_stack.recv_isotp(
+            self._transport, tx_id=addr[0], rx_id=addr[1]  # or however IDs are passed
+        )
+
+def ISOTPxmit_recv(self, data, IDtx=None, IDrx=None):
+    """Request-response via ISO-TP."""
+    if self.transport_mode == 'serial':
+        ...   # unchanged — firmware handles both sides.
+    else:
+        return isotp_stack.sendrecv_isotp(
+            self._transport, tx_id=IDtx, rx_id=IDrx, request_data=data
+        )
+```
+
+**Key design: the existing serial path stays completely untouched.** Only socketcan mode routes through `isotp_stack.py`. This means regression risk to the serial path is near-zero.
+
+### Step 3.5 — Handle receiver thread removal for socketcan
+
+The existing `_rxtx()` method spawns a background daemon thread that reads from serial and parses CAN frames into internal buffers (`self.rxbuf`, etc.). In socketcan mode:
+
+- **No receiver thread needed.** Blocking `recv_raw_can(timeout)` in the transport already handles framing.
+- For methods like `sniff()`, `CANreceive()`, etc., replace direct `_io.read()` calls with `self._transport.recv_raw_can()`.
+- Add a guard: Do **not** start `_rxtx()` when `self.transport_mode == 'socketcan'`.
+
+```python
+# In __init__:
+if self.transport_mode == 'serial':
+    # Start the existing receiver thread.
+    ...   # unchanged
+elif self.transport_mode == 'socketcan':
+    pass  # No background reader needed — blocking transport reads suffice.
+```
+
+### Step 3.6 — Update `ping()`, reconnect logic, and cleanup
+
+- **`CanInterface.ping()`**: Currently sends a ping command to firmware. For socketcan, override or short-circuit this (no device to ping). Option: check bus availability via transport.
+- **Reconnect / `_reconnect()`**: Only meaningful for serial. Skip entirely in socketcan mode.
+- **Destructor / cleanup**: Close `self._transport` on exit if open (use `atexit` or context manager pattern).
+
+### Step 3.7 — Verify subclasses are unaffected
+
+All `CanInterface` subclasses (`FordInterface`, `GMInterface`, `J1939`, etc.) call the parent `__init__()` and override specific methods. Since we only appended keyword arguments:
+
+```python
+class FordInterface(CanInterface):
+    def __init__(self, ...):
+        super().__init__('COM4', verbose=True)   # still works identically
+```
+
+Confirm by inspecting each subclass's `super().__init__()` call — none should break. If a subclass passes new kwargs via `**kwargs`, add `**kwargs` to our expanded signature for future safety.
+
+---
+
+## Phase 4: CLI Integration
+
+### Step 4.1 — Add `--socketcan IFACE` argument to CanCat entry point
+
+In `CanCat` (the main script at the repo root):
+
+```python
+parser.add_argument('-s', '--socketcan', metavar='IFACE',
+                    help='Use socketcan interface instead of serial device '
+                         '(e.g., can0, vcan0)')
+```
+
+### Step 4.2 — Wire argument through to CanInterface construction
+
+The entry point currently calls `interactive()` with the parsed args:
+
+```python
+# Existing line (approximate):
+results = interactive(ifo.port, intro=intro, InterfaceClass=interface,
+                      load_filename=ifo.filename, can_baud=baud_val)
+```
+
+Update to pass transport mode info through the appropriate parameter path (either via `interactive()` or directly to CanInterface):
+
+```python
+transport_args = {}
+if ifo.socketcan:
+    # --socketcan overrides --port; device is a network interface not a serial port.
+    transport_args['transport'] = 'socketcan'
+    transport_args['socketcan_iface'] = ifo.socketcan
+else:
+    assert ifo.port, "--port required (not using --socketcan)"
+
+results = interactive(..., **kwargs_to_pass_transport)  # adapt interactive() accordingly
+```
+
+If `interactive()` in `__init__.py` directly instantiates CanInterface, pass the new kwargs through to it.
+
+### Step 4.3 — Update dependency declarations
+
+In `setup.py`:
+
+```python
+install_requires = [
+    "ipython",
+    "pyserial",                 # only needed for serial mode
+    "pyusb",
+    "termcolor",
+    "future",
+    "six",
+    "isotp>=1.0",              # NEW: ISO-TP flow control stack (socketcan mode)
+],
+
+extras_require = {
+    'socketcan': [
+        'python-can>=4.0',     # NEW: socketcan backend + more
+    ],
+},
+```
+
+**Rationale for dependency placement:**
+- `isotp` → top-level because the UDS scanner (`cancatlib/uds`) and core CanInterface already use ISO-TP concepts internally; it's lightweight (~25 KB).
+- `python-can` → optional extra because: (a) serial-only users don't need it, (b) it pulls in Cython bindings that aren't built on all platforms by default.
+
+### Step 4.4 — Import-time guards for socketcan dependencies
+
+To avoid "python-can not installed" errors when running CanCat without the `socketcan` extra:
+
+```python
+# In cancatlib/transport.py or __init__.py
+def _get_socketcan_transport(iface):
+    try:
+        from .transport import SocketcanTransport
+        return SocketcanTransport(channel=iface)
+    except ImportError as e:
+        raise RuntimeError(
+            "socketcan transport requires 'python-can'. Install with: "
+            "pip install cancat[socketcan]"
+        ) from e
+
+def _get_isotp_stack():
+    try:
+        from . import isotp_stack
+        return isotp_stack
+    except ImportError as e:
+        raise RuntimeError(
+            "ISO-TP stack requires the 'isotp' library. Install with: "
+            "pip install isotp"
+        ) from e
+```
+
+---
+
+## Phase 5: Testing
+
+### Step 5.1 — Infrastructure: virtual CAN interface for testing
+
+Before running tests, set up a `vcan` interface on Linux:
+
+```bash
+sudo modprobe vcan          # Load kernel module if not loaded
+sudo ip link add dev vcan0 type vcan
+sudo ip link set up vcan0
+# Verify it exists:
+ip -details link show vcan0
+```
+
+The `vcan` interface supports loopback (frames sent on one end can be read by another process/reader on the same endpoint). This is ideal for unit testing without physical CAN hardware.
+
+### Step 5.2 — Unit test: SocketcanTransport basic send/recv
+
+```python
+# tests/test_socketcan_transport.py
+import threading, time, socket
+from cancatlib.transport import SocketcanTransport
+
+def test_send_recv_vcan():
+    """Send a CAN frame on one end of vcan0 and read it on the other."""
+    t1 = SocketcanTransport('vcan0')
+    t2 = SocketcanTransport('vcan0')   # Both read from same interface.
+    t1.open()
+    t2.open()
+
+    data = b'\xde\xad\xbe\xef'
+        
+    def sender():
+        time.sleep(0.1)  # Let receiver start first.
+        t1.send_raw_can(arbid=0x7DF, data=data, extflag=False)
+
+    threading.Thread(target=sender, daemon=True).start()
+    result = t2.recv_raw_can(timeout=2.0)
+    
+    assert result is not None
+    arbid_rx, data_rx, ext_rx = result
+    assert arbid_rx == 0x7DF
+    assert list(data_rx)[:4] == [0xde, 0xad, 0xbe, 0xef]
+    assert ext_rx == False
+
+    t1.close()
+    t2.close()
+```
+
+### Step 5.3 — Unit test: ISO-TP flow control through isotp_stack.py
+
+```python
+def test_isotp_multiframe():
+    """Send a 16-byte message (requires FF+CF frames) and verify FC handling."""
+    from cancatlib.isotp_stack import sendrecv_isotp
+    
+    t_tx = SocketcanTransport('vcan0')
+    t_rx = SocketcanTransport('vcan0')
+    t_tx.open()
+    t_rx.open()
+
+    # Large payload > 7 bytes, forces multi-frame ISO-TP.
+    payload = bytes(range(256))
+
+    def responder():
+        """Receive the request and send back a response."""
+        ...   # See Step 5.4 for full implementation sketch.
+
+    ...
+```
+
+Verify:
+- Sender segments into FF (First Frame) + CFs (Consecutive Frames).
+- Receiver sends FC (Flow Control) with valid BS and STmin before accepting CFs.
+- Complete payload reassembled correctly on the receiving end.
+- `sendrecv_isotp()` round-trips without data loss or corruption.
+
+### Step 5.4 — Integration test: CanInterface with socketcan transport
+
+```python
+def test_caninterface_socketcan():
+    """End-to-end: Create a CanInterface using socketcan, CANxmit and receive."""
+    from cancatlib import CanInterface
+    
+    c = CanInterface(transport='socketcan', socketcan_iface='vcan0')
+    
+    # Raw frame transmit + loopback receive (on vcan, send is readable by same bus).
+    arb_id = 0x123
+    msg_data = b'\x01\x02\x03'
+    c.CANxmit([arb_id, msg_data])
+
+    result = c._transport.recv_raw_can(timeout=1.0)
+    assert result[0] == arb_id
+    assert list(result[1])[:3] == [0x01, 0x02, 0x03]
+```
+
+### Step 5.5 — Regression test: existing serial tests still pass
+
+Run the full existing CanCat test suite with no modifications to confirm zero behavioral change to the serial path:
+
+```bash
+./venv/bin/python -m pytest tests/ -k "not socketcan" --ignore=tests/test_socketcan_transport.py --ignore=tests/test_isotp_stack.py -v
+```
+
+All pre-existing tests should pass. If any regress, the transport extraction in Phase 1 broke backwards compat — fix before proceeding.
+
+---
+
+## File Structure After Implementation
+
+```
+cancatlib/
+├── __init__.py          # Modified: CanInterface accepts transport params, routes CAN methods polymorphically.
+├── iso_tp.py            # Unchanged — static ISO-TP encode/decode helpers.
+├── isotp_stack.py       # NEW — Full ISO-TP flow control using python-isotp (socketcan mode).
+├── transport.py         # NEW — Transport ABC + SerialTransport + SocketcanTransport.
+└── ...                  # Existing submodules (uds, etc.) unchanged for serial path.
+
+docs/
+└── PLAN_SOCKETCAN.md    # This plan document.
+
+tests/
+├── test_socketcan_transport.py   # NEW — SocketcanTransport unit tests via vcan0.
+└── test_isotp_stack.py           # NEW — ISO-TP flow control integration tests via vcan0.
+
+CanCat                        # Modified: Added --socketcan CLI argument.
+setup.py                      # Modified: Added isotp, python-can[socketcan] dependencies.
+```
+
+---
+
+## Risk Assessment and Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Serial transport regression from extraction to `SerialTransport` | High | Keep serial branch code identical to original; no logic changes unless bug fixes explicitly tested against hardware. Fallback: keep original methods as legacy path behind the same ABC calls. |
+| `isotp.Protocol` API incompatibility with our callback pattern | Medium | Wrap all Protocol usage inside helper functions; don't expose protocol internals. Keep only one version of python-isotp pinned in deps. |
+| Subclass breaking from `__init__()` signature change | Low | Only append keyword-only arguments after existing positional args — verified by inspecting all subclass `super().__init__()`. |
+| Blocking serial operations (e.g., `.recv(timeout=0)` means "non-blocking"). Our wrapper must preserve these semantics. |

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,3 @@ ipython
 pyserial
 pyusb
 termcolor
-future
-six

--- a/setup.py
+++ b/setup.py
@@ -26,13 +26,11 @@ setuptools.setup  (name  = 'cancat',
         package_data     = pkgdata,
         ext_modules      = mods,
         scripts          = scripts,
-        install_requires = [    
+        install_requires = [
                 "ipython",
                 "pyserial",
                 "pyusb",
                 "termcolor",
-                "future",
-                "six",
             ],
         classifiers      = [
                             'Development Status :: 5 - Production/Stable',

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,9 @@ setuptools.setup  (name  = 'cancat',
                 "future",
                 "six",
             ],
+        extras_require = {
+                'socketcan': ['python-can>=3.0.0'],
+            },
         classifiers      = [
                             'Development Status :: 5 - Production/Stable',
                             'Intended Audience :: Telecommunications Industry',

--- a/tests/test_socketcan_j1939.py
+++ b/tests/test_socketcan_j1939.py
@@ -1,0 +1,183 @@
+"""Tests for socketcan support in CanInterface's cmdhandler dispatch and in
+J1939Interface -- both needed for J1939Cat -s <iface> to actually process
+messages live (PGN/TP reassembly, myIDs filtering) rather than just log raw
+frames.
+
+Unlike tests/test_transport.py these tests import cancatlib itself (pyserial
+required), so they're skipped rather than failing outright if that's not
+available in a given environment.
+
+Run:  python -m unittest tests.test_socketcan_j1939 -v
+"""
+import struct
+import time
+import unittest
+from unittest import mock
+
+try:
+    import serial  # noqa: F401 -- cancatlib/__init__.py needs this at import time
+    _HAVE_PYSERIAL = True
+except ImportError:
+    _HAVE_PYSERIAL = False
+
+
+class FakeCanMessage:
+    """Minimal fake can.Message for testing."""
+    def __init__(self, arbitration_id=0, data=b"", is_extended_id=False):
+        self.arbitration_id = arbitration_id
+        self.data = bytearray(data) if isinstance(data, bytes) else list(data)
+        self.is_extended_id = is_extended_id
+        self.dlc = len(self.data)
+
+
+class FakeCanBus:
+    """Fake can.Bus with send/recv for in-process testing."""
+
+    _send_queue = []
+    _sent_frames = []
+
+    def __init__(self, channel="can0", bustype="socketcan", bitrate=500000, receive_own_messages=False):
+        self.receive_own_messages = receive_own_messages
+        self._alive = True
+
+    def send(self, msg):
+        FakeCanBus._sent_frames.append(msg)
+        if self.receive_own_messages:
+            FakeCanBus._send_queue.append(msg)
+
+    def recv(self, timeout=1.0):
+        deadline = time.time() + timeout
+        while self._alive:
+            try:
+                return FakeCanBus._send_queue.pop(0)
+            except IndexError:
+                if time.time() >= deadline:
+                    return None
+                time.sleep(0.005)
+
+    def shutdown(self):
+        self._alive = False
+
+
+def _patch_can():
+    import sys
+    _can_mock = mock.MagicMock()
+    _can_mock.Bus = FakeCanBus
+    _can_mock.Message = FakeCanMessage
+    old_mod = sys.modules.get("can")
+    sys.modules["can"] = _can_mock
+
+    import cancatlib.transport as transport_mod
+    old_attr = getattr(transport_mod, "can", None)
+    transport_mod.can = _can_mock
+    return old_mod, old_attr, transport_mod
+
+
+def _unpatch_can(old_mod, old_attr, transport_mod):
+    import sys
+    if old_mod is None:
+        sys.modules.pop("can", None)
+    else:
+        sys.modules["can"] = old_mod
+    transport_mod.can = old_attr
+
+
+@unittest.skipUnless(_HAVE_PYSERIAL, "pyserial not installed")
+class TestSocketcanCmdHandlerDispatch(unittest.TestCase):
+    """CanInterface._socketcan_rx_loop must dispatch through self._cmdhandlers
+    (like the serial _rxtx() loop does) instead of always filing frames into
+    the generic CMD_CAN_RECV mailbox -- otherwise a subclass that registers a
+    live handler (e.g. J1939Interface) never sees socketcan traffic."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls._old_mod, cls._old_attr, cls._transport_mod = _patch_can()
+
+    @classmethod
+    def tearDownClass(cls):
+        _unpatch_can(cls._old_mod, cls._old_attr, cls._transport_mod)
+
+    def setUp(self):
+        FakeCanBus._send_queue.clear()
+        FakeCanBus._sent_frames.clear()
+
+    def test_registered_handler_is_invoked_for_socketcan_frames(self):
+        from cancatlib import CanInterface, CMD_CAN_RECV
+
+        c = CanInterface(port='FakeCanCat', transport='socketcan', socketcan_iface='vcan0')
+        try:
+            seen = []
+            c.register_handler(CMD_CAN_RECV, lambda tsmsg, canbuf: seen.append(tsmsg))
+
+            FakeCanBus._send_queue.append(FakeCanMessage(0x123, b"\xDE\xAD\xBE\xEF"))
+            deadline = time.time() + 2.0
+            while not seen and time.time() < deadline:
+                time.sleep(0.02)
+
+            self.assertEqual(len(seen), 1)
+            ts, msg = seen[0]
+            arbid = struct.unpack('>I', msg[:4])[0]
+            self.assertEqual(arbid, 0x123)
+            self.assertEqual(msg[4:], b"\xDE\xAD\xBE\xEF")
+
+            # A registered handler means CMD_CAN_RECV is NOT double-filed
+            # into the generic mailbox -- matches the serial _rxtx() behavior.
+            self.assertEqual(c._messages.get(CMD_CAN_RECV, []), [])
+        finally:
+            c._config['shutdown'] = True
+            c._transport.close()
+
+
+@unittest.skipUnless(_HAVE_PYSERIAL, "pyserial not installed")
+class TestJ1939InterfaceSocketcan(unittest.TestCase):
+    """J1939Interface must accept and forward transport/socketcan_iface so
+    J1939Cat -s <iface> can construct it (previously TypeError'd -- its
+    __init__ didn't accept those kwargs at all)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls._old_mod, cls._old_attr, cls._transport_mod = _patch_can()
+
+    @classmethod
+    def tearDownClass(cls):
+        _unpatch_can(cls._old_mod, cls._old_attr, cls._transport_mod)
+
+    def setUp(self):
+        FakeCanBus._send_queue.clear()
+        FakeCanBus._sent_frames.clear()
+
+    def test_constructs_with_socketcan_transport(self):
+        from cancatlib.j1939stack import J1939Interface
+
+        j = J1939Interface(port='FakeCanCat', transport='socketcan', socketcan_iface='vcan0')
+        try:
+            self.assertEqual(j.transport_mode, 'socketcan')
+        finally:
+            j._config['shutdown'] = True
+            j._transport.close()
+
+    def test_j1939_handler_fires_for_live_socketcan_frames(self):
+        from cancatlib.j1939stack import J1939Interface, J1939MSGS
+        from cancatlib.j1939 import emitArbid
+
+        j = J1939Interface(port='FakeCanCat', transport='socketcan', socketcan_iface='vcan0')
+        try:
+            # priority=6, edp=0, dp=0, PF=0xFE (broadcast PGN), PS=0xF0, SA=0x01
+            arbid = emitArbid(6, 0, 0, 0xFE, 0xF0, 0x01)
+            FakeCanBus._send_queue.append(
+                FakeCanMessage(arbid, b"\x01\x02\x03\x04\x05\x06\x07\x08", is_extended_id=True))
+
+            deadline = time.time() + 2.0
+            mbox = []
+            while not mbox and time.time() < deadline:
+                mbox = j._messages.get(J1939MSGS, [])
+                time.sleep(0.02)
+
+            self.assertEqual(len(mbox), 1)
+        finally:
+            j._config['shutdown'] = True
+            j._transport.close()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_socketcan_uds.py
+++ b/tests/test_socketcan_uds.py
@@ -128,12 +128,26 @@ class TestSocketcanUdsResponsePending(unittest.TestCase):
         try:
             u = uds.UDS(c, 0x7c0, timeout=2.0, verbose=False)
 
+            def wait_for_nth_frame(arbid, n, deadline):
+                """Wait until at least n frames with this arbid have been sent."""
+                while time.time() < deadline:
+                    if sum(1 for m in FakeCanBus._sent_frames if m.arbitration_id == arbid) >= n:
+                        return True
+                    time.sleep(0.01)
+                return False
+
             def ecu_sim():
                 deadline = time.time() + 2.0
-                while time.time() < deadline:
-                    if any(m.arbitration_id == 0x7c0 for m in FakeCanBus._sent_frames):
-                        break
-                    time.sleep(0.01)
+                # Request is 13 bytes (SID + DID + 10 data bytes) -- multi-frame:
+                # FF, then wait for our FC, then 1 CF. A real ECU can't evaluate
+                # the request (and so can't reply 0x78/positive/negative) until
+                # it has received all of it.
+                if not wait_for_nth_frame(0x7c0, 1, deadline):  # the FF
+                    return
+                FakeCanBus._send_queue.append(FakeCanMessage(0x7c8, bytes.fromhex('3000000000000000')))
+                if not wait_for_nth_frame(0x7c0, 2, deadline):  # the CF
+                    return
+
                 # NRC 0x78 for WriteDataByIdentifier (0x2e)
                 FakeCanBus._send_queue.append(FakeCanMessage(0x7c8, bytes.fromhex('037f2e7800000000')))
                 time.sleep(0.1)

--- a/tests/test_socketcan_uds.py
+++ b/tests/test_socketcan_uds.py
@@ -1,0 +1,153 @@
+"""Regression tests for UDS "response pending" (NRC 0x78) handling over
+socketcan.
+
+UDS.xmit_recv()'s retry-on-0x78 path calls CanInterface._isotp_get_msg(),
+which was originally a firmware/serial-mailbox-only implementation (it scans
+a position index into the raw CAN message log). Under socketcan that index
+is always None (there's no mailbox position -- see ISOTPxmit_recv()), so the
+retry path (`start_index=idx+1`) TypeError'd on `None + 1` the moment a real
+ECU used 0x78 to say "still working, give me more time."
+
+Like tests/test_socketcan_j1939.py these import cancatlib itself (pyserial
+required), so they're skipped rather than failing outright if that's not
+available.
+
+Run:  python -m unittest tests.test_socketcan_uds -v
+"""
+import time
+import threading
+import unittest
+from unittest import mock
+
+try:
+    import serial  # noqa: F401 -- cancatlib/__init__.py needs this at import time
+    _HAVE_PYSERIAL = True
+except ImportError:
+    _HAVE_PYSERIAL = False
+
+
+class FakeCanMessage:
+    def __init__(self, arbitration_id=0, data=b"", is_extended_id=False):
+        self.arbitration_id = arbitration_id
+        self.data = bytearray(data) if isinstance(data, bytes) else list(data)
+        self.is_extended_id = is_extended_id
+        self.dlc = len(self.data)
+
+
+class FakeCanBus:
+    _send_queue = []
+    _sent_frames = []
+
+    def __init__(self, channel="can0", bustype="socketcan", bitrate=500000, receive_own_messages=False):
+        self.receive_own_messages = receive_own_messages
+        self._alive = True
+
+    def send(self, msg):
+        FakeCanBus._sent_frames.append(msg)
+        if self.receive_own_messages:
+            FakeCanBus._send_queue.append(msg)
+
+    def recv(self, timeout=1.0):
+        deadline = time.time() + timeout
+        while self._alive:
+            try:
+                return FakeCanBus._send_queue.pop(0)
+            except IndexError:
+                if time.time() >= deadline:
+                    return None
+                time.sleep(0.005)
+
+    def shutdown(self):
+        self._alive = False
+
+
+def _patch_can():
+    import sys
+    _can_mock = mock.MagicMock()
+    _can_mock.Bus = FakeCanBus
+    _can_mock.Message = FakeCanMessage
+    old_mod = sys.modules.get("can")
+    sys.modules["can"] = _can_mock
+
+    import cancatlib.transport as transport_mod
+    old_attr = getattr(transport_mod, "can", None)
+    transport_mod.can = _can_mock
+    return old_mod, old_attr, transport_mod
+
+
+def _unpatch_can(old_mod, old_attr, transport_mod):
+    import sys
+    if old_mod is None:
+        sys.modules.pop("can", None)
+    else:
+        sys.modules["can"] = old_mod
+    transport_mod.can = old_attr
+
+
+@unittest.skipUnless(_HAVE_PYSERIAL, "pyserial not installed")
+class TestSocketcanUdsResponsePending(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls._old_mod, cls._old_attr, cls._transport_mod = _patch_can()
+
+    @classmethod
+    def tearDownClass(cls):
+        _unpatch_can(cls._old_mod, cls._old_attr, cls._transport_mod)
+
+    def setUp(self):
+        FakeCanBus._send_queue.clear()
+        FakeCanBus._sent_frames.clear()
+
+    def test_isotp_get_msg_waits_for_next_message_on_rx_arbid(self):
+        from cancatlib import CanInterface
+
+        c = CanInterface(port='FakeCanCat', transport='socketcan', socketcan_iface='vcan0')
+        try:
+            def send_later():
+                time.sleep(0.1)
+                FakeCanBus._send_queue.append(FakeCanMessage(0x7c8, bytes.fromhex('036edead00000000')))
+            threading.Thread(target=send_later, daemon=True).start()
+
+            msg, idx = c._isotp_get_msg(0x7c8, tx_arbid=0x7c0, timeout=2.0)
+            self.assertEqual(msg, bytes.fromhex('6edead'))
+            self.assertIsNone(idx)  # no mailbox position under socketcan
+        finally:
+            c._config['shutdown'] = True
+            c._transport.close()
+
+    def test_write_did_survives_response_pending(self):
+        """Regression test: a real ECU replying with NRC 0x78
+        (ResponseCorrectlyReceivedResponsePending) before its real answer
+        must not crash with TypeError: unsupported operand type(s) for
+        +: 'NoneType' and 'int'."""
+        from cancatlib import CanInterface
+        import cancatlib.uds as uds
+
+        c = CanInterface(port='FakeCanCat', transport='socketcan', socketcan_iface='vcan0')
+        try:
+            u = uds.UDS(c, 0x7c0, timeout=2.0, verbose=False)
+
+            def ecu_sim():
+                deadline = time.time() + 2.0
+                while time.time() < deadline:
+                    if any(m.arbitration_id == 0x7c0 for m in FakeCanBus._sent_frames):
+                        break
+                    time.sleep(0.01)
+                # NRC 0x78 for WriteDataByIdentifier (0x2e)
+                FakeCanBus._send_queue.append(FakeCanMessage(0x7c8, bytes.fromhex('037f2e7800000000')))
+                time.sleep(0.1)
+                # Real positive response: 0x6e 0xde 0xad
+                FakeCanBus._send_queue.append(FakeCanMessage(0x7c8, bytes.fromhex('036edead00000000')))
+
+            threading.Thread(target=ecu_sim, daemon=True).start()
+
+            result = u.WriteDID(0xdead, b'\x11\x22\x33\x44\x55\x66\x77\x88\x99\xaa')
+            self.assertEqual(result, bytes.fromhex('6edead'))
+        finally:
+            c._config['shutdown'] = True
+            c._transport.close()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -116,10 +116,11 @@ class FakeCanBus:
     _send_queue = []   # fake rx frames injected from outside
     _sent_frames = []  # record of sent frames for assertions
     
-    def __init__(self, channel="can0", bustype="socketcan", bitrate=500000):
+    def __init__(self, channel="can0", bustype="socketcan", bitrate=500000, receive_own_messages=False):
         self.channel = channel
         self.bustype = bustype
         self.bitrate = bitrate
+        self.receive_own_messages = receive_own_messages
         self._alive = True
 
     def send(self, msg):
@@ -278,6 +279,51 @@ class TestSocketcanTransport(unittest.TestCase):
         self.assertIsNone(result)
         self.t.close()
 
+    # ------------------------------------------------------------------
+    #  subscribe() fan-out
+    # ------------------------------------------------------------------
+
+    def test_subscribers_each_get_their_own_copy_of_a_frame(self):
+        """Two independent consumers (e.g. the logging thread and an
+        in-flight ISO-TP transaction) must each see every frame -- neither
+        should be able to steal it from the other."""
+        self.t.open()
+        try:
+            sub_a = self.t.subscribe()
+            sub_b = self.t.subscribe()
+
+            with self.t._lock_cond:
+                entry = (0x7E8, b"\x10\x14\x62\xF1\x90\x31", False)
+                self.t._recv_queue.append(entry)
+                self.t._lock_cond.notify()
+                for handle in self.t._subscribers:
+                    with handle["cond"]:
+                        handle["queue"].append(entry)
+                        handle["cond"].notify()
+
+            result_a = sub_a.recv_raw_can(timeout=1.0)
+            result_b = sub_b.recv_raw_can(timeout=1.0)
+            self.assertEqual(result_a, entry)
+            self.assertEqual(result_b, entry)
+        finally:
+            self.t.close()
+
+    def test_unsubscribe_stops_delivery(self):
+        self.t.open()
+        try:
+            sub = self.t.subscribe()
+            sub.close()
+            self.assertEqual(self.t._subscribers, [])
+        finally:
+            self.t.close()
+
+    def test_open_enables_receive_own_messages(self):
+        self.t.open()
+        try:
+            self.assertTrue(self.t._bus.receive_own_messages)
+        finally:
+            self.t.close()
+
 
 # =====================================================================
 #  IsoTpStack tests
@@ -309,7 +355,10 @@ class TestIsoTpStack(unittest.TestCase):
 
     def setUp(self):
         self.t = MockTransportForIsoTP()
-        self.stack = IsoTpStack(self.t)
+        # rx_id/tx_id match the 0x7E8 arbid used by the frames below so the
+        # stack's arbid filtering (it discards anything not addressed to
+        # rx_id) doesn't throw away the test's injected frames.
+        self.stack = IsoTpStack(self.t, rx_id=0x7E8, tx_id=0x7E0)
 
     # ------------------------------------------------------------------
     #  Single Frame send (<=6 bytes payload)
@@ -387,31 +436,90 @@ class TestIsoTpStack(unittest.TestCase):
         total_len = 20
         data_payload = os.urandom(total_len)
         
-        # First Frame: [0x10, len_hi, len_lo, <first 6 bytes>]
-        ff_pci = struct.pack("!BH", 0x10, total_len)
+        # First Frame: 2-byte PCI per ISO 15765-2 -- top nibble of byte 0 is
+        # the FF type, bottom nibble + byte 1 hold the 12-bit length -- then
+        # <first 6 bytes>.
+        ff_pci = struct.pack("BB", 0x10 | ((total_len >> 8) & 0x0F), total_len & 0xFF)
         ff_frame = (0x7E8, ff_pci + data_payload[:6], False)
         
-        # Consecutive Frames: [SN | 0xF0, <up to 7 bytes>]
-        # Stack expects first CF SN=0 (line 135 in isotp_stack.py)
+        # Consecutive Frames: [0x20 | SN, <up to 7 bytes>] -- ISO 15765-2 CF
+        # type nibble is 0x2, and SN starts at 1 for the first CF.
         cf_frames = []
-        sn = 0
+        sn = 1
         offset = 6
         while offset < total_len:
             chunk = data_payload[offset:offset + 7]
-            cf_frame = (0x7E8, struct.pack("B", (sn & 0xF) | 0x30) + chunk, False)
+            cf_frame = (0x7E8, struct.pack("B", 0x20 | (sn & 0xF)) + chunk, False)
             cf_frames.append(cf_frame)
             sn = (sn + 1) & 0xF
             offset += 7
-        
+
         # Mock transport: inject_recv() uses insert(0), recv_raw_can() uses pop(0).
         # To get FIFO output [FF, CF1, CF2], queue must be [FF, CF1, CF2].
         # Achieve with: inject reverse-CFs first (so earliest CF ends up at front), then FF last.
         for cf in reversed(cf_frames):     # cf_frames is [CF1, CF2,...] → reversed puts them in right order after prepends
             self.t.inject_recv(cf)
         self.t.inject_recv(ff_frame)       # injected last = pops first from index 0
-        
+
         result = self.stack.receive(timeout=3.0)
         self.assertEqual(result, data_payload[:total_len])
+
+        # receive() must send a Flow Control frame right after the First
+        # Frame so the ECU knows to keep sending Consecutive Frames --
+        # without it a real ECU just times out and never sends them.
+        self.assertEqual(len(self.t._send_log), 1)
+        fc_arbid, fc_data, _ = self.t._send_log[0]
+        self.assertEqual(fc_arbid, 0x7E0)  # our tx_id
+        self.assertEqual((fc_data[0] & 0xF0) >> 4, 0x3)  # FC type
+        self.assertEqual(fc_data[0] & 0x0F, 0x0)  # ContinueToSend
+
+    def test_receive_multiframe_ignores_frames_for_other_arbids(self):
+        """Frames not addressed to our rx_id (e.g. other bus traffic, or our
+        own echoed tx frame when receive_own_messages is enabled) must not
+        be mistaken for part of this transaction."""
+        total_len = 20
+        data_payload = os.urandom(total_len)
+
+        ff_pci = struct.pack("BB", 0x10 | ((total_len >> 8) & 0x0F), total_len & 0xFF)
+        ff_frame = (0x7E8, ff_pci + data_payload[:6], False)
+
+        cf_frames = []
+        sn = 1
+        offset = 6
+        while offset < total_len:
+            chunk = data_payload[offset:offset + 7]
+            cf_frames.append((0x7E8, struct.pack("B", 0x20 | (sn & 0xF)) + chunk, False))
+            sn = (sn + 1) & 0xF
+            offset += 7
+
+        # Interleave unrelated frames (e.g. our own echoed request, or
+        # another ECU's chatter) ahead of each real frame.
+        stray = (0x7E0, b"\x03\x22\xF1\x90", False)  # our own echoed request
+        other_ecu = (0x123, b"\x00" * 8, False)
+
+        self.t.inject_recv(other_ecu)
+        for cf in reversed(cf_frames):
+            self.t.inject_recv(cf)
+            self.t.inject_recv(stray)
+        self.t.inject_recv(ff_frame)
+        self.t.inject_recv(stray)
+
+        result = self.stack.receive(timeout=3.0)
+        self.assertEqual(result, data_payload[:total_len])
+
+    def test_receive_multiframe_real_ecu_bytes(self):
+        """Regression test using the exact frame bytes captured off a real
+        ECU's ReadDataByIdentifier(0xF190) response -- a First Frame whose
+        2-byte PCI (0x10 0x14) must decode to length 20, not be misread as a
+        3-byte PCI (which previously misparsed the length as 0x1462)."""
+        # inject_recv() prepends, so inject in reverse order to get the
+        # real FIFO wire order [FF, CF1, CF2] back out of recv_raw_can().
+        self.t.inject_recv((0x7E8, bytes.fromhex("22ffffffffffffff"), False))
+        self.t.inject_recv((0x7E8, bytes.fromhex("21ffffffffffffff"), False))
+        self.t.inject_recv((0x7E8, bytes.fromhex("101462f190ffffff"), False))
+
+        result = self.stack.receive(timeout=3.0)
+        self.assertEqual(result, bytes.fromhex("62f190") + b"\xff" * 17)
 
     # ------------------------------------------------------------------
     #  Receive timeout

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,0 +1,427 @@
+"""Unit tests for the CAN transport abstraction layer + ISO-TP stack.
+
+Tests run entirely in-process with mocked backends — no hardware, vcan, or root required.
+
+Run:  cd /opt/data/cancat && python -m unittest tests.test_transport -v
+       or:   .venv/bin/python -m pytest tests/test_transport.py -v
+"""
+import importlib.util
+import os
+import struct
+import threading
+import time
+import unittest
+from unittest import mock
+
+
+# ---------------------------------------------------------------------------
+# Import transport module directly, bypassing cancatlib/__init__.py which pulls in
+# heavy deps (pyserial) not needed for these tests.
+# ---------------------------------------------------------------------------
+_transport_path = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "..", "cancatlib", "transport.py"
+)
+_spec = importlib.util.spec_from_file_location("transport", _transport_path)
+_transport_mod = importlib.util.module_from_spec(_spec)
+assert _spec is not None and _spec.loader is not None, "bad spec"
+_spec.loader.exec_module(_transport_mod)
+
+Transport = _transport_mod.Transport
+SerialTransport = _transport_mod.SerialTransport
+SocketcanTransport = _transport_mod.SocketcanTransport
+
+
+# Import isoip_stack module directly
+_isotp_path = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "..", "cancatlib", "isotp_stack.py"
+)
+_isotp_spec = importlib.util.spec_from_file_location("isotp_stack", _isotp_path)
+_isotp_mod = importlib.util.module_from_spec(_isotp_spec)
+assert _isotp_spec is not None and _isotp_spec.loader is not None, "bad isotp spec"
+_isotp_spec.loader.exec_module(_isotp_mod)
+
+IsoTpStack = _isotp_mod.IsoTpStack
+
+
+# =====================================================================
+#  Abstract base class tests
+# =====================================================================
+
+
+class TestAbstractBase(unittest.TestCase):
+
+    def test_open_raises(self):
+        with self.assertRaises(NotImplementedError):
+            Transport().open()
+
+    def test_send_raw_can_raises(self):
+        with self.assertRaises(NotImplementedError):
+            Transport().send_raw_can(0x123, b"")
+
+    def test_recv_raw_can_raises(self):
+        with self.assertRaises(NotImplementedError):
+            Transport().recv_raw_can()
+
+
+# =====================================================================
+#  SerialTransport tests
+# =====================================================================
+
+
+class TestSerialTransport(unittest.TestCase):
+
+    def setUp(self):
+        self.t = SerialTransport("/dev/null")
+
+    def test_recv_returns_enqued_frame(self):
+        frame = (0x123, b"\xAA\xBB", False)
+        with self.t._lock_cond:
+            self.t._can_recv_queue.append(frame)
+            self.t._lock_cond.notify()
+        result = self.t.recv_raw_can(timeout=0.5)
+        self.assertEqual(result, frame)
+
+    def test_recv_returns_none_on_timeout(self):
+        result = self.t.recv_raw_can(timeout=0.1)
+        self.assertIsNone(result)
+
+    def test_close_with_no_io(self):
+        self.t.close()
+
+    def test_xmit_delegates_to_send(self):
+        with mock.patch.object(self.t, "send_raw_can") as stub:
+            self.t.xmit_raw_can(0x7FF, b"\x12", extflag=True)
+            stub.assert_called_once_with(0x7FF, b"\x12", extflag=True)
+
+
+# =====================================================================
+#  Mocked python-can bus for SocketcanTransport tests
+# =====================================================================
+
+class FakeCanMessage:
+    """Minimal fake can.Message for testing."""
+    def __init__(self, arbitration_id=0, data=b"", is_extended_id=False):
+        self.arbitration_id = arbitration_id
+        self.data = bytearray(data) if isinstance(data, bytes) else list(data)
+        self.is_extended_id = is_extended_id
+        self.dlc = len(self.data)
+
+    def __bytes__(self):
+        return bytes(self.data)
+
+
+class FakeCanBus:
+    """Fake can.Bus with send/recv for in-process testing."""
+    
+    _send_queue = []   # fake rx frames injected from outside
+    _sent_frames = []  # record of sent frames for assertions
+    
+    def __init__(self, channel="can0", bustype="socketcan", bitrate=500000):
+        self.channel = channel
+        self.bustype = bustype
+        self.bitrate = bitrate
+        self._alive = True
+
+    def send(self, msg):
+        if not self._alive:
+            raise RuntimeError("Bus shut down")
+        FakeCanBus._sent_frames.append(msg)
+
+    def recv(self, timeout=1.0):
+        deadline = time.time() + timeout
+        while self._alive:
+            try:
+                return FakeCanBus._send_queue.pop(0)
+            except IndexError:
+                if time.time() >= deadline:
+                    return None
+                time.sleep(0.01)
+
+    def shutdown(self):
+        self._alive = False
+
+
+# Global mock replacement for the `can` module
+_can_mock = mock.MagicMock()
+_can_mock.Bus = FakeCanBus
+_can_mock.Message = FakeCanMessage
+
+
+def _patch_can():
+    """Insert fake 'can' into sys.modules and patch transport module attr."""
+    import sys
+    old_mod = sys.modules.get("can")
+    sys.modules["can"] = _can_mock
+    
+    # Also patch on the transport module in case it cached `can` as an attribute
+    patch_obj = mock.patch.object(_transport_mod, "can", new=_can_mock, create=True)
+    return old_mod, patch_obj
+
+
+def _unpatch_can(old_mod):
+    """Restore original sys.modules['can'] state."""
+    import sys
+    if old_mod is None:
+        sys.modules.pop("can", None)
+    else:
+        sys.modules["can"] = old_mod
+
+
+class TestSocketcanTransport(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls._old_can, cls._patch_obj = _patch_can()
+        cls._patch_obj.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._patch_obj.stop()
+        _unpatch_can(cls._old_can)
+
+    def setUp(self):
+        self.t = SocketcanTransport(channel="can0", bitrate=500000)
+        FakeCanBus._sent_frames.clear()
+        FakeCanBus._send_queue.clear()
+        _can_mock.reset_mock()
+
+    # ------------------------------------------------------------------
+    #  open / close
+    # ------------------------------------------------------------------
+
+    def test_open_starts_bus_and_thread(self):
+        self.t.open()
+        time.sleep(0.05)
+        self.assertIsNotNone(self.t._bus)
+        self.assertTrue(self.t._running)
+        self.assertIsNotNone(self.t._rx_thread)
+        self.t.close()
+
+    def test_close_stops_and_shuts_down(self):
+        self.t.open()
+        time.sleep(0.05)
+        self.t.close()
+        self.assertFalse(self.t._running)
+        self.assertIsNone(self.t._bus)
+
+    # ------------------------------------------------------------------
+    #  send_raw_can
+    # ------------------------------------------------------------------
+
+    def test_send_pads_data_to_8_bytes(self):
+        self.t.open()
+        try:
+            self.t.send_raw_can(0x123, b"\x01\x02")
+            sent = FakeCanBus._sent_frames[-1]
+            self.assertEqual(len(sent.data), 8)
+            self.assertEqual(bytes(sent.data[:2]), b"\x01\x02")
+        finally:
+            self.t.close()
+
+    def test_send_forwards_arbid_and_extflag(self):
+        self.t.open()
+        try:
+            self.t.send_raw_can(0x7FF, b"\xFF", extflag=True)
+            sent = FakeCanBus._sent_frames[-1]
+            self.assertEqual(sent.arbitration_id, 0x7FF)
+            self.assertTrue(sent.is_extended_id)
+        finally:
+            self.t.close()
+
+    def test_send_calls_bus_send(self):
+        mock_bus_ref = [None]
+        
+        # Monkey-patch the bus after open
+        self.t.open()
+        try:
+            self.t.send_raw_can(0x100, b"\xAA")
+            self.assertEqual(len(FakeCanBus._sent_frames), 1)
+        finally:
+            self.t.close()
+
+    def test_send_raises_when_not_open(self):
+        with self.assertRaises(RuntimeError):
+            self.t.send_raw_can(0x1, b"")
+
+    # ------------------------------------------------------------------
+    #  recv_raw_can
+    # ------------------------------------------------------------------
+
+    def test_recv_returns_enqueued_frame(self):
+        mock_bus = mock.MagicMock()
+        mock_bus.recv.return_value = None
+        _can_mock.Bus.return_value = mock_bus
+        
+        self.t.open()
+        time.sleep(0.02)
+        
+        with self.t._lock_cond:
+            self.t._recv_queue.append((0x456, b"\xDE\xAD", False))
+            self.t._lock_cond.notify()
+        
+        result = self.t.recv_raw_can(timeout=1.0)
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result), 3)
+        self.t.close()
+
+    def test_recv_returns_none_on_timeout(self):
+        mock_bus = mock.MagicMock()
+        mock_bus.recv.return_value = None
+        _can_mock.Bus.return_value = mock_bus
+        
+        self.t.open()
+        time.sleep(0.12)  # wait for rx poll cycle to drain
+        with self.t._lock_cond:
+            self.t._recv_queue.clear()
+        
+        result = self.t.recv_raw_can(timeout=0.1)
+        self.assertIsNone(result)
+        self.t.close()
+
+
+# =====================================================================
+#  IsoTpStack tests
+# =====================================================================
+
+class MockTransportForIsoTP:
+    """Mock transport for IsoTpStack testing — records sends, injects receives."""
+    
+    def __init__(self):
+        self._send_log = []      # list of (arbid, data_bytes, extflag)
+        self._recv_queue = []    # frames to be returned by recv_raw_can
+    
+    def send_raw_can(self, arbid, data, extflag=False):
+        self._send_log.append((arbid, data, extflag))
+
+    def recv_raw_can(self, timeout=1.0):
+        if not self._recv_queue:
+            # Block briefly then return None (timeout behavior)
+            time.sleep(min(timeout, 0.1))
+            return None
+        return self._recv_queue.pop(0)
+
+    def inject_recv(self, frame_tuple):
+        """Prepend a frame to the recv queue so next recv_raw_can returns it."""
+        self._recv_queue.insert(0, frame_tuple)
+
+
+class TestIsoTpStack(unittest.TestCase):
+
+    def setUp(self):
+        self.t = MockTransportForIsoTP()
+        self.stack = IsoTpStack(self.t)
+
+    # ------------------------------------------------------------------
+    #  Single Frame send (<=6 bytes payload)
+    # ------------------------------------------------------------------
+
+    def test_send_single_frame(self):
+        data = b"\x10\x01"  # UDS diagnostic request example
+        result = self.stack.send(0x7DF, data, extflag=False)
+        
+        self.assertTrue(result)
+        self.assertEqual(len(self.t._send_log), 1)
+        arbid, frame_data, _ = self.t._send_log[0]
+        self.assertEqual(arbid, 0x7DF)
+        # Single Frame: PCI byte + data -> [0x02, 0x10, 0x01]
+        self.assertEqual(frame_data[0], 0x02)  # type=SF (0x00), len=2
+        self.assertEqual(bytes(frame_data[1:]), data)
+
+    def test_send_single_frame_max(self):
+        data = b"\x10\x01\x22\xF1\x90\x00"  # exactly 6 bytes -> single frame
+        result = self.stack.send(0x7DF, data, extflag=False)
+        
+        self.assertTrue(result)
+        arbid, frame_data, _ = self.t._send_log[0]
+        self.assertEqual(frame_data[0], 0x06)  # SF type + length=6
+
+    # ------------------------------------------------------------------
+    #  Multi-frame send (>6 bytes payload)
+    # ------------------------------------------------------------------
+
+    def test_send_multiframe_sends_ff(self):
+        data = b"\x10\x01" + b"\x48" * 20  # >6 bytes, triggers multi-frame
+        total_len = len(data)
+        
+        # Inject Flow Control responses so the stack can proceed with CFs
+        for _ in range(total_len // 7 + 1):
+            fc_frame = (0x7E8, struct.pack("BBB", 0x30, 0x00, 0x00), False)
+            self.t.inject_recv(fc_frame)
+        
+        result = self.stack.send(0x7DF, data, extflag=False)
+        self.assertTrue(result)
+        self.assertGreater(len(self.t._send_log), 1)
+        
+        # Verify First Frame header format: [0x10, total_len_hi, total_len_lo, data...]
+        ff = self.t._send_log[0][1]
+        self.assertEqual((ff[0] & 0xF0) >> 4, 0x1)  # FF type
+
+    def test_send_multiframe_handles_overflow_error(self):
+        data = b"\x10\x01" + b"\x48" * 20
+        
+        # Inject overflow error FC as the first response so tx aborts after FF
+        fc_error = (0x7E8, struct.pack("BBB", 0x32, 0x00, 0x00), False)
+        self.t.inject_recv(fc_error)
+        
+        result = self.stack.send(0x7DF, data, extflag=False)
+        # Stack should return False on overflow error
+        self.assertFalse(result)
+
+    # ------------------------------------------------------------------
+    #  Single Frame receive
+    # ------------------------------------------------------------------
+
+    def test_receive_single_frame(self):
+        ff_data = struct.pack("B", 0x03) + b"\x51\x01\x40"  # SF, len=3
+        frame_tuple = (0x7E8, ff_data.rstrip(b'\x00')[:4], False)
+        self.t.inject_recv(frame_tuple)
+        
+        result = self.stack.receive(timeout=1.0)
+        self.assertEqual(result, b"\x51\x01\x40")
+
+    # ------------------------------------------------------------------
+    #  Multi-frame receive
+    # ------------------------------------------------------------------
+
+    def test_receive_multiframe(self):
+        total_len = 20
+        data_payload = os.urandom(total_len)
+        
+        # First Frame: [0x10, len_hi, len_lo, <first 6 bytes>]
+        ff_pci = struct.pack("!BH", 0x10, total_len)
+        ff_frame = (0x7E8, ff_pci + data_payload[:6], False)
+        
+        # Consecutive Frames: [SN | 0xF0, <up to 7 bytes>]
+        # Stack expects first CF SN=0 (line 135 in isotp_stack.py)
+        cf_frames = []
+        sn = 0
+        offset = 6
+        while offset < total_len:
+            chunk = data_payload[offset:offset + 7]
+            cf_frame = (0x7E8, struct.pack("B", (sn & 0xF) | 0x30) + chunk, False)
+            cf_frames.append(cf_frame)
+            sn = (sn + 1) & 0xF
+            offset += 7
+        
+        # Mock transport: inject_recv() uses insert(0), recv_raw_can() uses pop(0).
+        # To get FIFO output [FF, CF1, CF2], queue must be [FF, CF1, CF2].
+        # Achieve with: inject reverse-CFs first (so earliest CF ends up at front), then FF last.
+        for cf in reversed(cf_frames):     # cf_frames is [CF1, CF2,...] → reversed puts them in right order after prepends
+            self.t.inject_recv(cf)
+        self.t.inject_recv(ff_frame)       # injected last = pops first from index 0
+        
+        result = self.stack.receive(timeout=3.0)
+        self.assertEqual(result, data_payload[:total_len])
+
+    # ------------------------------------------------------------------
+    #  Receive timeout
+    # ------------------------------------------------------------------
+
+    def test_receive_timeout(self):
+        # No frames injected — should return None
+        result = self.stack.receive(timeout=0.1)
+        self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -405,6 +405,39 @@ class TestIsoTpStack(unittest.TestCase):
         ff = self.t._send_log[0][1]
         self.assertEqual((ff[0] & 0xF0) >> 4, 0x1)  # FF type
 
+    def test_send_multiframe_waits_for_fc_only_once_when_bs_is_zero(self):
+        """Regression test: send() must only wait for ONE Flow Control frame
+        for the whole transfer when the ECU's FC says BS=0 (no block size
+        limit) -- it must NOT wait for another FC before every single CF.
+        20 bytes needs a FF + 2 CFs; only one FC is injected, so this hangs
+        (and eventually times out/fails) if the bug regresses."""
+        data = b"\x10\x01" + b"\x48" * 18  # 20 bytes -> FF(6) + CF(7) + CF(7)
+        fc_frame = (0x7E8, struct.pack("BBB", 0x30, 0x00, 0x00), False)  # BS=0, STmin=0
+        self.t.inject_recv(fc_frame)
+
+        result = self.stack.send(0x7DF, data, extflag=False)
+        self.assertTrue(result)
+
+        # FF + 2 CFs sent, and the single injected FC is the only frame the
+        # stack ever tried to receive.
+        self.assertEqual(len(self.t._send_log), 3)
+        cf1 = self.t._send_log[1][1]
+        cf2 = self.t._send_log[2][1]
+        self.assertEqual(cf1[0] & 0x0F, 0x1)  # CF sequence number 1
+        self.assertEqual(cf2[0] & 0x0F, 0x2)  # CF sequence number 2
+
+    def test_send_multiframe_waits_for_fc_per_block_when_bs_is_nonzero(self):
+        """With a block size of 1, the ECU should be asked for a fresh FC
+        before every single CF (BS=1 means "one CF per block")."""
+        data = b"\x10\x01" + b"\x48" * 18  # 20 bytes -> FF(6) + CF(7) + CF(7)
+        # BS=1: send one CF, then wait for another FC before the next one.
+        self.t.inject_recv((0x7E8, struct.pack("BBB", 0x30, 0x01, 0x00), False))
+        self.t.inject_recv((0x7E8, struct.pack("BBB", 0x30, 0x01, 0x00), False))
+
+        result = self.stack.send(0x7DF, data, extflag=False)
+        self.assertTrue(result)
+        self.assertEqual(len(self.t._send_log), 3)  # FF + CF + CF
+
     def test_send_multiframe_handles_overflow_error(self):
         data = b"\x10\x01" + b"\x48" * 20
         


### PR DESCRIPTION
Adds socketcan support to CanCat. All the fresh minty CanCat goodness with none of the unavailable hardware aftertaste.